### PR TITLE
Add function `OwnedKeyValueList::id`, which returns a unique id for the node

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,11 @@ impl OwnedKeyValueList {
     pub fn iter(&self) -> OwnedKeyValueListIterator {
         OwnedKeyValueListIterator::new(self)
     }
+
+    /// Get a unique stable identifier for this node
+    pub fn id(&self) -> usize {
+        &*self.inner as *const _ as usize
+    }
 }
 
 /// Iterator over `OwnedKeyValue`-s


### PR DESCRIPTION
`slog-term` relies on being able to extract unique stable idenfiers from nodes in `OwnedKeyValueList`s. Part of the fix for slog-rs/term#1.