### PR TITLE
Updated slog_serde to allow length parameter.

### DIFF
--- a/crates/json/lib.rs
+++ b/crates/json/lib.rs
@@ -139,7 +139,7 @@ impl slog_stream::Format for Format {
 
         let io = {
             let serializer = serde_json::Serializer::new(io);
-            let mut serializer = try!(SerdeSerializer::start(serializer));
+            let mut serializer = try!(SerdeSerializer::start(serializer, None));
 
             for (ref k, ref v) in self.values.iter() {
                 try!(v.serialize(rinfo, k, &mut serializer));

--- a/crates/serde/lib.rs
+++ b/crates/serde/lib.rs
@@ -33,9 +33,9 @@ pub struct SerdeSerializer<S: serde::Serializer>{
 impl<S: serde::Serializer> SerdeSerializer<S> {
 
     /// Start serializing map of values
-    pub fn start(mut ser : S) -> result::Result<Self, ser::Error> {
+    pub fn start(mut ser : S, len: Option<usize>) -> result::Result<Self, ser::Error> {
         let map_state = try!(
-            ser.serialize_map(None)
+            ser.serialize_map(len)
                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "serde serialization error"))
         );
         Ok(SerdeSerializer {


### PR DESCRIPTION
Also updated slog_json to use it. Users of slog_json will see no change;
it is purely internal.

This resolves #85.