### PR TITLE
Update URL to examples repository

### DIFF
--- a/examples.txt
+++ b/examples.txt
@@ -1,1 +1,1 @@
-Examples have been moved to: https://github.com/slog-rs/gittest/tree/master/examples
+Examples have been moved to: https://github.com/slog-rs/misc/tree/master/examples


### PR DESCRIPTION
It's now called `misc` rather than `gittest`.