### PR TITLE
Added description of slog compile features to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ In Cargo.toml:
 slog = "1.2"
 ```
 
+Enabling/restricting max log levels via features:
+
+```
+[dependencies]
+slog = "1.2"
+features = ["max_log_level_trace", "release_max_log_level_trace"]
+```
+
+Each level has an associated feature for both debug and release builds.
+
 In your `main.rs`:
 
 ```


### PR DESCRIPTION
I've added some documentation about the compile time features to the 'In Your Project' section of the README.md.

Lost some time this AM trying to figure out why my trace messages were never logged.   Forgot about the default debug level restriction on a build with default features.