### PR TITLE
Add FromStr implementation for Level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1315,6 +1315,22 @@ impl Level {
     }
 }
 
+impl FromStr for Level {
+    type Err = ();
+    fn from_str(s: &str) -> core::result::Result<Level, ()> {
+        let result = match &s.to_lowercase()[..] {
+            "critical" => Level::Critical,
+            "error" => Level::Error,
+            "warning" => Level::Warning,
+            "info" => Level::Info,
+            "debug" => Level::Debug,
+            "trace" => Level::Trace,
+            _ => return Err(())
+        };
+        Ok(result)
+    }
+}
+
 impl FilterLevel {
     /// Convert to `usize` value
     ///


### PR DESCRIPTION
## Motivation

Slog uses builder pattern to construct darins programmaticaly. One of the functions available for drain construction is level_filter. level_filter accepts Level.

```
let console_drain = level_filter(console_log_level, streamer().compact().stderr().build());
```

This derivation allows for using Level enum in libraries like clap (or other config libraries), to parse Log level directly from options, for example like this:

```rust
use slog;
use clap;

...
Arg::from_usage("--console-level [LOG_LEVEL] 'Console logging level'")
                    .default_value("WARN")
                    .possible_values(&slog::LOG_LEVEL_NAMES)])
...

let console_level = value_t!(matches.value_of("console_level"), slog::Level)
        .expect("Unexpected logging level!");
let console_drain = level_filter(console_log_level, streamer().compact().stderr().build());
...

```
This spares the user writing the conversion function from string option to Enum himself, can be used with other configuration libraries too.