### PR TITLE
Fix build on nightly rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2860,12 +2860,13 @@ impl core::fmt::Display for Error {
 /// rust during time of the release. It will be switched to `!` at some point
 /// and `Never` should not be considered "stable" API.
 #[doc(hidden)]
-pub type Never = NeverStruct;
+pub type Never = private::NeverStruct;
 
-#[doc(hidden)]
-#[derive(Debug)]
-#[allow(private_in_public)]
-struct NeverStruct(());
+mod private {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub struct NeverStruct(());
+}
 
 /// This is not part of "stable" API
 #[doc(hidden)]


### PR DESCRIPTION
Hi.
https://github.com/rust-lang/rust/pull/42125 is going to turn some old compatibility "private-in-public" warnings in `rustc` into hard errors.
`crates.io` testing discovered that published version of this crate is affected by one of those errors.
This PR updates the code to build successfully with https://github.com/rust-lang/rust/pull/42125
