### PR TITLE
`fmt::Arguments<'static>` should not be `Sync`

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -225,8 +225,6 @@ impl<'a> Serialize for fmt::Arguments<'a>{
     }
 }
 
-impl SyncSerialize for fmt::Arguments<'static> {}
-
 impl SyncSerialize for &'static str {}
 
 impl Serialize for String {


### PR DESCRIPTION
This is an unsoundness that will be fixed in a future rustc version

Fix is in https://github.com/rust-lang/rust/pull/45198#issuecomment-336982478