### PR TITLE
Opaque Keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ lto = true
 debug-assertions = false
 
 [features]
-
 std = []
 default = ["std"]
+opaque-keys = []
 
 max_level_off   = []
 max_level_error = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 [dev-dependencies]
-slog-term = "2"
+slog-term = { git = 'https://github.com/valarauca/term', branch = 'opaque_keys'}
 slog-async = "2"
 
 [patch.crates-io]

--- a/examples/struct-log-self.rs
+++ b/examples/struct-log-self.rs
@@ -22,6 +22,7 @@ impl Peer {
 }
 
 // `KV` can be implemented for a struct
+#[cfg(not(feature = "opaque-keys"))]
 impl KV for Peer {
     fn serialize(
         &self,
@@ -31,6 +32,19 @@ impl KV for Peer {
 
         serializer.emit_u32("peer-port", self.port)?;
         serializer.emit_str("peer-host", &self.host)?;
+        Ok(())
+    }
+}
+#[cfg(feature = "opaque-keys")]
+impl KV for Peer {
+    fn serialize(
+        &self,
+        _record: &Record,
+        serializer: &mut Serializer,
+    ) -> Result {
+
+        serializer.emit_u32(Key::from("peer-port"), self.port)?;
+        serializer.emit_str(Key::from("peer-host"), &self.host)?;
         Ok(())
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -1,0 +1,16 @@
+
+#[cfg(all(feature = "opaque-keys", feature = "std"))]
+mod opaque_key_std;
+#[cfg(all(feature = "opaque-keys", feature = "std"))]
+pub use self::opaque_key_std::Key;
+
+#[cfg(not(feature = "opaque-keys"))]
+mod old_key;
+#[cfg(not(feature = "opaque-keys"))]
+pub use self::old_key::Key;
+
+#[cfg(all(feature = "opaque-keys", not(feature = "std")))]
+mod opaque_key_nostd;
+#[cfg(all(feature = "opaque-keys", not(feature = "std")))]
+pub use self::opaque_key_nostd::Key;
+

--- a/src/key/old_key.rs
+++ b/src/key/old_key.rs
@@ -1,0 +1,3 @@
+
+
+pub type Key = &'static str;

--- a/src/key/opaque_key_nostd.rs
+++ b/src/key/opaque_key_nostd.rs
@@ -1,0 +1,168 @@
+
+use alloc::String;
+use alloc::borrow::Cow;
+use alloc::Clone;
+
+use core::convert::{From,Into,AsRef};
+use core::ops::Deref;
+use core::str::FromStr;
+use core::cmp::PartialEq;
+use core::hash::{Hash,Hasher};
+use core::iter::{FromIterator, IntoIterator};
+use core::fmt;
+
+/// Opaque Key is a representation of a key.
+///
+/// It is owned, and largely forms a contract for
+/// key to follow.
+pub struct Key {
+    data: Cow<'static, str>
+}
+impl Key {
+
+    pub fn as_str<'a>(&'a self) -> &'a str {
+        self.data.as_ref()
+    }
+
+    pub fn into_string(&self) -> String {
+        match &self.data {
+            &Cow::Borrowed(ptr) => String::from(ptr),
+            &Cow::Owned(ref ptr) => ptr.clone()
+        }
+    }
+
+    pub fn into_owned(&self) -> String {
+        match &self.data {
+            &Cow::Borrowed(ptr) => String::from(ptr),
+            &Cow::Owned(ref ptr) => ptr.clone()
+        }
+    }
+}
+impl Default for Key {
+    fn default() -> Key {
+        Key {
+            data: Cow::Borrowed("")
+        }
+    }
+}
+impl Hash for Key {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.data {
+            Cow::Borrowed(ref ptr) => ptr.hash(state),
+            Cow::Owned(ref ptr) => ptr.hash(state)
+        }
+    }
+}
+impl Clone for Key {
+    fn clone(&self) -> Key {
+        match self.data {
+            Cow::Borrowed(ptr) => Key::from(ptr)
+            Cow::Owned(ref ptr) => Key::from(ptr.clone())
+        }
+    }
+}
+impl From<&'static str> for Key {
+    #[inline(always)]
+    fn from(data: &'static str) -> Key {
+        Key {
+            data: Cow::Borrowed(data)
+        }
+    }
+}
+impl From<String> for Key {
+    #[inline(always)]
+    fn from(data: String) -> Key {
+        Key{
+            data: Cow::Owned(data)
+        }
+    }
+}
+impl Into<String> for Key {
+    #[inline(always)]
+    fn into(self) -> String {
+        self.data.into_owned()
+    }
+}
+impl FromIterator<char> for Key {
+    fn from_iter<I: IntoIterator<Item=char>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a char> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a char>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl FromIterator<String> for Key {
+    fn from_iter<I: IntoIterator<Item=String>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a String> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a String>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().map(|x| x.as_str()).collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a str> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a str>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<Cow<'a,str>> for Key {
+    fn from_iter<I: IntoIterator<Item=Cow<'a,str>>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl PartialEq<str> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &str) -> bool {
+        self.as_ref().eq(other)
+    }
+}
+impl PartialEq<String> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &String) -> bool {
+        self.as_ref().eq(other.as_str())
+    }
+}
+impl PartialEq<Self> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+impl AsRef<str> for Key {
+    #[inline(always)]
+    fn as_ref<'a>(&'a self) -> &'a str {
+        self.data.as_ref()
+    }
+}
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.data {
+            Cow::Borrowed(ref ptr) => write!(f, "{}", ptr),
+            Cow::Owned(ref ptr) => write!(f, "{}", ptr)
+        }
+    }
+}
+impl fmt::Debug for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.data {
+            Cow::Borrowed(ref ptr) => write!(f, "{:?}", ptr),
+            Cow::Owned(ref ptr) => write!(f, "{:?}", ptr)
+        }
+    }
+}
+

--- a/src/key/opaque_key_std.rs
+++ b/src/key/opaque_key_std.rs
@@ -1,0 +1,166 @@
+
+use std::borrow::Cow;
+use std::convert::{From,Into,AsRef};
+use std::ops::Deref;
+use std::str::FromStr;
+use std::cmp::PartialEq;
+use std::hash::{Hash,Hasher};
+use std::iter::{FromIterator, IntoIterator};
+use std::string::String;
+use std::fmt;
+
+/// Opaque Key is a representation of a key.
+///
+/// It is owned, and largely forms a contract for
+/// key to follow.
+pub struct Key {
+    data: Cow<'static, str>
+}
+impl Key {
+
+    pub fn as_str<'a>(&'a self) -> &'a str {
+        self.data.as_ref()
+    }
+
+    pub fn into_string(&self) -> String {
+        match &self.data {
+            &Cow::Borrowed(ptr) => String::from(ptr),
+            &Cow::Owned(ref ptr) => ptr.clone()
+        }
+    }
+
+    pub fn into_owned(&self) -> String {
+        match &self.data {
+            &Cow::Borrowed(ptr) => String::from(ptr),
+            &Cow::Owned(ref ptr) => ptr.clone()
+        }
+    }
+}
+impl Default for Key {
+    fn default() -> Key {
+        Key {
+            data: Cow::Borrowed("")
+        }
+    }
+}
+impl Hash for Key {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.data {
+            Cow::Borrowed(ref ptr) => ptr.hash(state),
+            Cow::Owned(ref ptr) => ptr.hash(state)
+        }
+    }
+}
+impl Clone for Key {
+    fn clone(&self) -> Key {
+        match self.data {
+            Cow::Borrowed(ptr) => Key::from(ptr),
+            Cow::Owned(ref ptr) => Key::from(ptr.clone())
+        }
+    }
+}
+impl From<&'static str> for Key {
+    #[inline(always)]
+    fn from(data: &'static str) -> Key {
+        Key {
+            data: Cow::Borrowed(data)
+        }
+    }
+}
+impl From<String> for Key {
+    #[inline(always)]
+    fn from(data: String) -> Key {
+        Key{
+            data: Cow::Owned(data)
+        }
+    }
+}
+impl Into<String> for Key {
+    #[inline(always)]
+    fn into(self) -> String {
+        self.data.into_owned()
+    }
+}
+impl FromIterator<char> for Key {
+    fn from_iter<I: IntoIterator<Item=char>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a char> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a char>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl FromIterator<String> for Key {
+    fn from_iter<I: IntoIterator<Item=String>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a String> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a String>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().map(|x| x.as_str()).collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<&'a str> for Key {
+    fn from_iter<I: IntoIterator<Item=&'a str>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl<'a> FromIterator<Cow<'a,str>> for Key {
+    fn from_iter<I: IntoIterator<Item=Cow<'a,str>>>(iter: I) -> Key {
+        Key {
+            data: Cow::Owned(iter.into_iter().collect::<String>())
+        }
+    }
+}
+impl PartialEq<str> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &str) -> bool {
+        self.as_ref().eq(other)
+    }
+}
+impl PartialEq<String> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &String) -> bool {
+        self.as_ref().eq(other.as_str())
+    }
+}
+impl PartialEq<Self> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+impl AsRef<str> for Key {
+    #[inline(always)]
+    fn as_ref<'a>(&'a self) -> &'a str {
+        self.data.as_ref()
+    }
+}
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.data {
+            Cow::Borrowed(ref ptr) => write!(f, "{}", ptr),
+            Cow::Owned(ref ptr) => write!(f, "{}", ptr)
+        }
+    }
+}
+impl fmt::Debug for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.data {
+            Cow::Borrowed(ref ptr) => write!(f, "{:?}", ptr),
+            Cow::Owned(ref ptr) => write!(f, "{:?}", ptr)
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,22 +402,46 @@ macro_rules! slog_b(
 #[macro_export]
 macro_rules! kv(
     (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); $($args)* )
+        }
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); $($args)* )
+        }
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
-        kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => $v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); $($args)* )
+        }
     };
     (@ $args_ready:expr; $kv:expr) => {
         kv!(@ ($kv, $args_ready); )
@@ -440,22 +464,46 @@ macro_rules! kv(
 #[macro_export]
 macro_rules! slog_kv(
     (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
+        } else {
+            slog_kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
+        } else {
+            slog_kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); $($args)* )
+        } 
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
+        } else {
+            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); $($args)* )
+        }
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
-        slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
+        if cfg!(not(features = "opaque-keys")) {
+            slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
+        } else {
+            slog_kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); )
+        }
     };
     (@ $args_ready:expr; $k:expr => $v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
+        if cfg!(not(features = "opaque-keys")) {
+            slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
+        } else {
+            slog_kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); $($args)* )
+        }
     };
     (@ $args_ready:expr; $slog_kv:expr) => {
         slog_kv!(@ ($slog_kv, $args_ready); )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,9 @@ extern crate collections;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod key;
+pub use self::key::Key;
+
 #[cfg(not(feature = "std"))]
 use alloc::arc::Arc;
 #[cfg(not(feature = "std"))]
@@ -320,7 +323,6 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 #[cfg(not(feature = "std"))]
 use collections::string::String;
-
 
 use core::{convert, fmt, result};
 
@@ -336,6 +338,8 @@ use std::rc::Rc;
 use std::string::String;
 #[cfg(feature = "std")]
 use std::sync::Arc;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 // }}}
 
 // {{{ Macros
@@ -2264,10 +2268,6 @@ where
 }
 // }}}
 
-// {{{ Key
-/// Key type (alias for &'static str)
-pub type Key = &'static str;
-// }}}
 
 // {{{ Value
 /// Value that can be serialized
@@ -2498,7 +2498,7 @@ impl<'a> PushFnValueSerializer<'a> {
     /// This consumes `self` to prevent serializing one value multiple times
     pub fn emit<'b, S: 'b + Value>(mut self, s: S) -> Result {
         self.done = true;
-        s.serialize(self.record, self.key, self.serializer)
+        s.serialize(self.record, self.key.clone(), self.serializer)
     }
 }
 
@@ -2506,7 +2506,7 @@ impl<'a> Drop for PushFnValueSerializer<'a> {
     fn drop(&mut self) {
         if !self.done {
             // unfortunately this gives no change to return serialization errors
-            let _ = self.serializer.emit_unit(self.key);
+            let _ = self.serializer.emit_unit(self.key.clone());
         }
     }
 }
@@ -2645,7 +2645,7 @@ where
         record: &Record,
         serializer: &mut Serializer,
     ) -> Result {
-        self.1.serialize(record, self.0, serializer)
+        self.1.serialize(record, self.0.clone(), serializer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-// {{{ Crate docs
 //! # Slog -  Structured, extensible, composable logging for Rust
 //!
 //! `slog-rs` is an ecosystem of reusable components for structured, extensible,
@@ -402,46 +401,22 @@ macro_rules! slog_b(
 #[macro_export]
 macro_rules! kv(
     (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); $($args)* )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{:?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); $($args)* )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{:?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => $v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); $($args)* )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $kv:expr) => {
         kv!(@ ($kv, $args_ready); )
@@ -464,46 +439,22 @@ macro_rules! kv(
 #[macro_export]
 macro_rules! slog_kv(
     (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); )
-        } else {
-            slog_kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); )
-        }
+        slog_kv!(@ ($crate::SingleKV::from(($k, format_args!("{}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            slog_kv!(@ ($crate::SingleKV($k, format_args!("{}", $v)), $args_ready); $($args)* )
-        } else {
-            slog_kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{}", $v)), $args_ready); $($args)* )
-        } 
+        slog_kv!(@ ($crate::SingleKV::from(($k, format_args!("{}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{:?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            kv!(@ ($crate::SingleKV($k, format_args!("{:?}", $v)), $args_ready); $($args)* )
-        } else {
-            kv!(@ ($crate::SingleKV(Key::from($k), format_args!("{:?}", $v)), $args_ready); $($args)* )
-        }
+        kv!(@ ($crate::SingleKV::from(($k, format_args!("{:?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
-        if cfg!(not(features = "opaque-keys")) {
-            slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); )
-        } else {
-            slog_kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); )
-        }
+        slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => $v:expr, $($args:tt)* ) => {
-        if cfg!(not(features = "opaque-keys")) {
-            slog_kv!(@ ($crate::SingleKV($k, $v), $args_ready); $($args)* )
-        } else {
-            slog_kv!(@ ($crate::SingleKV(Key::from($k), $v), $args_ready); $($args)* )
-        }
+        slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $slog_kv:expr) => {
         slog_kv!(@ ($slog_kv, $args_ready); )
@@ -703,7 +654,7 @@ macro_rules! slog_record(
 /// It's possible to directly specify type that implements `KV` trait without
 /// `=>` syntax.
 ///
-/// ```
+/// ```ignore
 /// #[macro_use]
 /// extern crate slog;
 ///
@@ -2280,7 +2231,7 @@ pub trait Serializer {
     impl_default_as_fmt!(f64, emit_f64);
     /// Emit str
     impl_default_as_fmt!(&str, emit_str);
-
+    
     /// Emit `()`
     fn emit_unit(&mut self, key: Key) -> Result {
         self.emit_arguments(key, &format_args!("()"))
@@ -2297,6 +2248,7 @@ pub trait Serializer {
     /// to retain type information most serious `Serializer`s will want to
     /// implement all other methods as well.
     fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> Result;
+
 }
 
 /// Serializer to closure adapter.
@@ -2682,6 +2634,25 @@ where
 pub struct SingleKV<V>(pub Key, pub V)
 where
     V: Value;
+
+#[cfg(feature = "opaque-keys")]
+impl<V: Value> From<(String,V)> for SingleKV<V> {
+    fn from(x: (String,V)) -> SingleKV<V> {
+        SingleKV(Key::from(x.0),x.1)
+    }
+}
+#[cfg(feature = "opaque-keys")]
+impl<V: Value> From<(&'static str, V)> for SingleKV<V> {
+    fn from(x: (&'static str, V)) -> SingleKV<V> {
+        SingleKV(Key::from(x.0), x.1)
+    }
+}
+#[cfg(not(feature = "opaque-keys"))]
+impl<V: Value> From<(&'static str, V)> for SingleKV<V> {
+    fn from(x: (&'static str, V)) -> SingleKV<V> {
+        SingleKV(x.0, x.1)
+    }
+}
 
 
 impl<V> KV for SingleKV<V>


### PR DESCRIPTION
We chatted on Glitter, the goal is allow for variable key value pairs.

---

All new code is behind a feature gate. It is extremely low impact. There are follow up PR's to `slog-term` and `slog-json` but they're mostly just ensuring `emit_name(&mut self, key: Key` is enforced not `emit_name(&mut self, key: &str` which keeps forward/backward compatibility. 