### PR TITLE
Add a Drain::is_enabled method to check if a message should be logged.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Structured, extensible, composable logging for Rust"
 keywords = ["log", "logging", "structured", "hierarchical"]


### PR DESCRIPTION
This can be used to avoid expensive computation of log message arguments
if the message would be ignored anyway.
This is added as a condition in the `log!` macro,
in order to avoid unnecessarily computing the arguments when the level is disabled.

This is the (somewhat nicer) slog alternative to `log` crate's `log_enabled!` macro.
I've taken the liberty of bumping the version so you can hopefully push a new release ;)