### PR TITLE
Add a blanket implementation of Drain for references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1448,6 +1448,22 @@ pub trait Drain {
         self.map(Fuse)
     }
 }
+impl<'a, D: Drain + 'a> Drain for &'a D {
+    type Ok = D::Ok;
+    type Err = D::Err;
+    #[inline]
+    fn log(
+        &self,
+        record: &Record,
+        values: &OwnedKVList,
+    ) -> result::Result<Self::Ok, Self::Err> {
+        (**self).log(record, values)
+    }
+    #[inline]
+    fn is_enabled(&self, level: Level) -> bool {
+        (**self).is_enabled(level)
+    }
+}
 
 #[cfg(feature = "std")]
 /// `Send + Sync + UnwindSafe` bound

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -237,3 +237,14 @@ fn logger_to_erased() {
 
     takes_arced_drain(log.into_erased());
 }
+
+#[test]
+fn logger_by_ref() {
+    use ::*;
+    let drain = Discard.filter_level(Level::Warning).map(Fuse);
+    let log = Logger::root_typed(drain, o!("version" => env!("CARGO_PKG_VERSION")));
+    let f = "f";
+    let d = (1, 2);
+    info!(&log, "message"; "f" => %f, "d" => ?d);
+}
+


### PR DESCRIPTION
This fixes using references to loggers in macros.
I've added a test to prevent further regressions.
Fixes #164