### PR TITLE
Implement Value for 128 bit integers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ cache:
   - cargo
 rust:
   - stable
-  - 1.15.0
+  - 1.26.2
   - beta
   - nightly
 
 script:
     # `patch` section is recent addition
-  - if [ "$TRAVIS_RUST_VERSION" != "1.15.0" ]; then make all ; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "1.15.0" ]; then make build ; fi
-  - if [ "$TRAVIS_RUST_VERSION" != "1.15.0" ]; then make travistest ; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "1.26.2" ]; then make all ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "1.26.2" ]; then make build ; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "1.26.2" ]; then make travistest ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then make bench ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features; cargo test --no-default-features; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --manifest-path crates/test_edition2018/Cargo.toml; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.4.0 - 2018-09-18
+## 2.4.0 - 2018-09-19
 
 * Implement Value for 128 bit integers
+* Add support 2018-style macro imports
 * Bump miminum supported Rust version to 1.26
 
 ## 2.3.3 - 2018-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.0 - 2018-09-18
+
+* Implement Value for 128 bit integers
+* Bump miminum supported Rust version to 1.26
+
 ## 2.3.3 - 2018-07-20
 
 * `impl Value for SocketAddr`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog"
-version = "2.3.3"
+version = "2.4.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Structured, extensible, composable logging for Rust"
 keywords = ["log", "logging", "structured", "hierarchical"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2477,6 +2477,10 @@ pub trait Serializer {
     impl_default_as_fmt!(i64, emit_i64);
     /// Emit f64
     impl_default_as_fmt!(f64, emit_f64);
+    /// Emit u128
+    impl_default_as_fmt!(u128, emit_u128);
+    /// Emit i128
+    impl_default_as_fmt!(i128, emit_i128);
     /// Emit str
     impl_default_as_fmt!(&str, emit_str);
 
@@ -2642,6 +2646,8 @@ impl_value_for!(f32, emit_f32);
 impl_value_for!(u64, emit_u64);
 impl_value_for!(i64, emit_i64);
 impl_value_for!(f64, emit_f64);
+impl_value_for!(u128, emit_u128);
+impl_value_for!(i128, emit_i128);
 
 impl Value for () {
     fn serialize(


### PR DESCRIPTION
Now that 128 bit ints are stable, slog should probably add support for them. Not sure if this needs to be/can be gated on compiler version to avoid increasing the minimum required version.