### PR TITLE
impl Value for SocketAddr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2753,6 +2753,17 @@ impl<'a> Value for std::path::Display<'a> {
     }
 }
 
+impl Value for std::net::SocketAddr {
+    fn serialize(
+        &self,
+        _record: &Record,
+        key: Key,
+        serializer: &mut Serializer,
+    ) -> Result {
+        serializer.emit_arguments(key, &format_args!("{}", self))
+    }
+}
+
 /// Explicit lazy-closure `Value`
 pub struct FnValue<V: Value, F>(pub F)
 where


### PR DESCRIPTION
This addresses essentially what is described in #109. The suggestion there to use % for types that are `Display` may not work all the times. In cases when you do not know the exact type of arguments you are logging you may find the requirement for `Display` too strict. (Such use case may arise inside a macro when you have to accept whatever your consumer is passing you)

Anyway, this is pretty straightforward. If there are better ways to achieve the same results I'd be glad to learn.