### PR TITLE
remove dev-dependency on slog-term/slog-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,5 @@ release_max_level_trace = []
 [dependencies]
 erased-serde = { version = "0.3", optional = true }
 
-[dev-dependencies]
-slog-term = "2"
-slog-async = "2"
-
 [package.metadata.docs.rs]
 features = ["std", "nested-values", "dynamic-keys"]

--- a/examples/named.rs
+++ b/examples/named.rs
@@ -1,20 +1,15 @@
 //#![feature(trace_macros)]
 #[macro_use]
 extern crate slog;
-extern crate slog_async;
-extern crate slog_term;
-use slog::Drain;
+use slog::{Fuse, Logger};
 
+mod common;
 
 fn main() {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator)
-        .use_original_order()
-        .build()
-        .fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-
-    let log = slog::Logger::root(drain, o!("version" => "0.5"));
+    let log = Logger::root(
+        Fuse(common::PrintlnDrain),
+        o!("version" => "2")
+    );
 
     //trace_macros!(true);
     info!(log, "foo is {foo}", foo = 2; "a" => "b");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //!
 //! ### Logging to the terminal
 //!
-//! ```
+//! ```ignore
 //! #[macro_use]
 //! extern crate slog;
 //! extern crate slog_term;
@@ -131,7 +131,7 @@
 //!
 //! ### Logging to a file
 //!
-//! ```
+//! ```ignore
 //! #[macro_use]
 //! extern crate slog;
 //! extern crate slog_term;
@@ -164,7 +164,7 @@
 //!
 //! ### Change logging level at runtime
 //!
-//! ```
+//! ```ignore
 //! #[macro_use]
 //! extern crate slog;
 //! extern crate slog_term;
@@ -275,7 +275,7 @@
 //!
 //! Create simple terminal logger like this:
 //!
-//! ```
+//! ```ignore
 //! #[macro_use]
 //! extern crate slog;
 //! extern crate slog_term;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,14 +301,11 @@
 
 // {{{ Imports & meta
 #![cfg_attr(not(feature = "std"), feature(alloc))]
-#![cfg_attr(not(feature = "std"), feature(collections))]
 #![warn(missing_docs)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-#[cfg(not(feature = "std"))]
-extern crate collections;
 #[macro_use]
 #[cfg(feature = "std")]
 extern crate std;
@@ -316,13 +313,13 @@ extern crate std;
 mod key;
 pub use self::key::Key;
 #[cfg(not(feature = "std"))]
-use alloc::arc::Arc;
+use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::rc::Rc;
 #[cfg(not(feature = "std"))]
-use collections::string::String;
+use alloc::string::String;
 
 #[cfg(feature = "nested-values")]
 extern crate erased_serde;


### PR DESCRIPTION
The dependencies on slog-term and slog-async in example codes cause cyclic dependencies problems.
This PR modifies it to use a dummy drain instead.
