### PR TITLE
enable workspace configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - if [ "$TRAVIS_RUST_VERSION" != "1.15.1" ]; then make travistest ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then make bench ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features; cargo test --no-default-features; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --manifest-path crates/test_edition2018/Cargo.toml; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test -p test_edition2018; fi
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,8 @@ erased-serde = { version = "0.3", optional = true }
 
 [package.metadata.docs.rs]
 features = ["std", "nested-values", "dynamic-keys"]
+
+[workspace]
+members = [
+  "crates/test_edition2018",
+]

--- a/crates/test_edition2018/Cargo.toml
+++ b/crates/test_edition2018/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test_edition2018"
 version = "0.0.0"
-edition = "2018"
 description = "A crate for testing 2018-style macro imports"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 publish = false
@@ -9,6 +8,7 @@ publish = false
 [lib]
 path = "lib.rs"
 name = "test_edition2018"
+doc = false
 
 [dependencies]
 slog = { path = "../.." }

--- a/crates/test_edition2018/lib.rs
+++ b/crates/test_edition2018/lib.rs
@@ -1,3 +1,5 @@
+extern crate slog;
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
The feature flag `use_extern_macros` is stabilized at 1.30 and the field `edition = '2018'` in `Cargo.toml` is no longer required.
This PR register `test_edition2018` into the member of workspace in order to share `target/`. (Since the old `cargo` rejects the crate when someone in the members of workspace has `edition` field, the test crate was completely separated.)
The item `[workspace]` will be removed at publishing and hence there is no affect to the released crates.

Edited: blocked on #197 due to fix nightly regression.