### PR TITLE
remove some impls of `Value` on no-std target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2814,6 +2814,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> Value for std::path::Display<'a> {
     fn serialize(
         &self,
@@ -2825,6 +2826,7 @@ impl<'a> Value for std::path::Display<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl Value for std::net::SocketAddr {
     fn serialize(
         &self,


### PR DESCRIPTION
Note: a similar situation is reported in https://github.com/rust-lang/rust/pull/54671#issuecomment-431214638.