### PR TITLE
Add a "nothreads" feature to drop Send+Sync requirements from OwnedKV.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ debug-assertions = false
 nested-values = ["erased-serde"]
 dynamic-keys = []
 std = []
+nothreads = []
 default = ["std"]
 
 max_level_off   = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/slog"
 homepage = "https://github.com/slog-rs/slog"
 repository = "https://github.com/slog-rs/slog"
 readme = "README.md"
+autoexamples = true
 
 build = "build.rs"
 
@@ -48,6 +49,10 @@ release_max_level_trace = []
 
 [dependencies]
 erased-serde = { version = "0.3", optional = true }
+
+[[example]]
+name = "singlethread"
+required-features = ["nothreads"]
 
 [package.metadata.docs.rs]
 features = ["std", "nested-values", "dynamic-keys"]

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ longtest:
 	@i=0; while i=$$((i + 1)) && echo "Iteration $$i" && make test ; do :; done
 
 .PHONY: $(EXAMPLES)
-$(EXAMPLES):
+named struct-log-self:
 	cargo build --example $@ $(CARGO_FLAGS)
+singlethread:
+	cargo build --features nothreads --example $@ $(CARGO_FLAGS)
 
 .PHONY: doc
 doc: FORCE

--- a/examples/singlethread.rs
+++ b/examples/singlethread.rs
@@ -1,0 +1,29 @@
+//#![feature(nothreads)]
+#[macro_use]
+extern crate slog;
+use slog::{Fuse, Logger};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod common;
+
+#[derive(Clone)]
+struct NoThreadSafeObject {
+    val: Rc<RefCell<usize>>,
+}
+
+fn main() {
+    let log = Logger::root(Fuse(common::PrintlnDrain), o!("version" => "2"));
+    let obj = NoThreadSafeObject {
+        val: Rc::new(RefCell::new(4)),
+    };
+
+    // Move obj2 into a closure. Since it's !Send, this only works
+    // with nothreads feature.
+    let obj2 = obj.clone();
+    let sublog = log.new(o!("obj.val" => slog::FnValue(move |_| {
+        format!("{}", obj2.val.borrow())
+    })));
+
+    info!(sublog, "test");
+}

--- a/examples/struct-log-self.rs
+++ b/examples/struct-log-self.rs
@@ -6,7 +6,6 @@ use slog::*;
 
 mod common;
 
-
 struct Peer {
     host: String,
     port: u32,
@@ -22,33 +21,13 @@ impl Peer {
 }
 
 // `KV` can be implemented for a struct
-#[cfg(not(feature = "opaque-keys"))]
 impl KV for Peer {
-    fn serialize(
-        &self,
-        _record: &Record,
-        serializer: &mut Serializer,
-    ) -> Result {
-
-        serializer.emit_u32("peer-port", self.port)?;
-        serializer.emit_str("peer-host", &self.host)?;
-        Ok(())
-    }
-}
-#[cfg(feature = "opaque-keys")]
-impl KV for Peer {
-    fn serialize(
-        &self,
-        _record: &Record,
-        serializer: &mut Serializer,
-    ) -> Result {
-
+    fn serialize(&self, _record: &Record, serializer: &mut Serializer) -> Result {
         serializer.emit_u32(Key::from("peer-port"), self.port)?;
         serializer.emit_str(Key::from("peer-host"), &self.host)?;
         Ok(())
     }
 }
-
 
 struct Server {
     _host: String,
@@ -59,11 +38,9 @@ struct Server {
     log: Logger,
 }
 
-
 impl Server {
     fn new(host: String, port: u32, log: Logger) -> Server {
-        let log =
-            log.new(o!("server-host" => host.clone(), "server-port" => port));
+        let log = log.new(o!("server-host" => host.clone(), "server-port" => port));
         Server {
             _host: host,
             _port: port,
@@ -102,10 +79,7 @@ impl PeerCounter {
 }
 
 fn main() {
-    let log = Logger::root(
-        Fuse(common::PrintlnDrain),
-        o!("build-id" => "7.3.3-abcdef"),
-    );
+    let log = Logger::root(Fuse(common::PrintlnDrain), o!("build-id" => "7.3.3-abcdef"));
 
     let server = Server::new("localhost".into(), 12345, log.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3032,29 +3032,28 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "nothreads")]
 /// Thread-local safety bound for `KV`
 ///
 /// This type is used to enforce `KV`s stored in `Logger`s are thread-safe.
+pub trait SendSyncRefUnwindSafeKV: KV {}
+
+#[cfg(feature = "nothreads")]
+impl<T> SendSyncRefUnwindSafeKV for T where T: KV + ?Sized {}
+
+#[cfg(all(not(feature = "nothreads"), feature = "std"))]
+/// This type is used to enforce `KV`s stored in `Logger`s are thread-safe.
 pub trait SendSyncRefUnwindSafeKV: KV + Send + Sync + RefUnwindSafe {}
 
-#[cfg(feature = "std")]
-impl<T> SendSyncRefUnwindSafeKV for T
-where
-    T: KV + Send + Sync + RefUnwindSafe + ?Sized,
-{
-}
+#[cfg(all(not(feature = "nothreads"), feature = "std"))]
+impl<T> SendSyncRefUnwindSafeKV for T where T: KV + Send + Sync + RefUnwindSafe + ?Sized {}
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "nothreads"), not(feature = "std")))]
 /// This type is used to enforce `KV`s stored in `Logger`s are thread-safe.
 pub trait SendSyncRefUnwindSafeKV: KV + Send + Sync {}
 
-#[cfg(not(feature = "std"))]
-impl<T> SendSyncRefUnwindSafeKV for T
-where
-    T: KV + Send + Sync + ?Sized,
-{
-}
+#[cfg(all(not(feature = "nothreads"), not(feature = "std")))]
+impl<T> SendSyncRefUnwindSafeKV for T where T: KV + Send + Sync + ?Sized {}
 
 /// Single pair `Key` and `Value`
 pub struct SingleKV<V>(pub Key, pub V)


### PR DESCRIPTION
When using slog in a single-threading context, the Send+Sync
requirement means that we cannot use non-threadsafe objects
as values or as part of a lazy value callback. This feature
flag provides support for this scenario in a backward compatible
way.