### PR TITLE
Level parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ cache:
   - cargo
 rust:
   - stable
-  - 1.15.1
+  - 1.23.0
   - beta
   - nightly
 
 script:
     # `patch` section is recent addition
-  - if [ "$TRAVIS_RUST_VERSION" != "1.15.1" ]; then make all ; fi
-  - if [ "$TRAVIS_RUST_VERSION" == "1.15.1" ]; then make build ; fi
-  - if [ "$TRAVIS_RUST_VERSION" != "1.15.1" ]; then make travistest ; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "1.23.0" ]; then make all ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "1.23.0" ]; then make build ; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "1.23.0" ]; then make travistest ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then make bench ; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features; cargo test --no-default-features; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test -p test_edition2018; fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2182,45 +2182,13 @@ impl FilterLevel {
     }
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
-static ASCII_LOWERCASE_MAP: [u8; 256] =
-    [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
-     0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-     0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, b' ', b'!', b'"', b'#',
-     b'$', b'%', b'&', b'\'', b'(', b')', b'*', b'+', b',', b'-', b'.', b'/',
-     b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b':', b';',
-     b'<', b'=', b'>', b'?', b'@', b'a', b'b', b'c', b'd', b'e', b'f', b'g',
-     b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's',
-     b't', b'u', b'v', b'w', b'x', b'y', b'z', b'[', b'\\', b']', b'^', b'_',
-     b'`', b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j', b'k',
-     b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w',
-     b'x', b'y', b'z', b'{', b'|', b'}', b'~', 0x7f, 0x80, 0x81, 0x82, 0x83,
-     0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
-     0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b,
-     0x9c, 0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
-     0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3,
-     0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
-     0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb,
-     0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7,
-     0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3,
-     0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
-     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb,
-     0xfc, 0xfd, 0xfe, 0xff];
-
 impl FromStr for Level {
     type Err = ();
     fn from_str(level: &str) -> core::result::Result<Level, ()> {
         LOG_LEVEL_NAMES
             .iter()
-            .position(|&name| {
-                name.as_bytes().iter().zip(level.as_bytes().iter()).all(
-                    |(a, b)| {
-                        ASCII_LOWERCASE_MAP[*a as usize]
-                            == ASCII_LOWERCASE_MAP[*b as usize]
-                    },
-                )
-            })
-            .map(|p| Level::from_usize(p).unwrap())
+            .position(|name| name.eq_ignore_ascii_case(level))
+            .and_then(|p| Level::from_usize(p))
             .ok_or(())
     }
 }
@@ -2230,15 +2198,8 @@ impl FromStr for FilterLevel {
     fn from_str(level: &str) -> core::result::Result<FilterLevel, ()> {
         LOG_LEVEL_NAMES
             .iter()
-            .position(|&name| {
-                name.as_bytes().iter().zip(level.as_bytes().iter()).all(
-                    |(a, b)| {
-                        ASCII_LOWERCASE_MAP[*a as usize]
-                            == ASCII_LOWERCASE_MAP[*b as usize]
-                    },
-                )
-            })
-            .map(|p| FilterLevel::from_usize(p).unwrap())
+            .position(|name| name.eq_ignore_ascii_case(level))
+            .and_then(|p| FilterLevel::from_usize(p))
             .ok_or(())
     }
 }
@@ -2265,7 +2226,7 @@ fn level_at_least() {
 }
 
 #[test]
-fn filterlevel_sanity() {
+fn filter_level_sanity() {
     assert!(Level::Critical.as_usize() > FilterLevel::Off.as_usize());
     assert!(Level::Critical.as_usize() == FilterLevel::Critical.as_usize());
     assert!(Level::Trace.as_usize() == FilterLevel::Trace.as_usize());
@@ -2273,7 +2234,72 @@ fn filterlevel_sanity() {
 
 #[test]
 fn level_from_str() {
-    assert_eq!("info".parse::<FilterLevel>().unwrap(), FilterLevel::Info);
+    refute_from_str::<Level>("off");
+    assert_from_str(Level::Critical, "critical");
+    assert_from_str(Level::Error, "error");
+    assert_from_str(Level::Warning, "warn");
+    assert_from_str(Level::Info, "info");
+    assert_from_str(Level::Debug, "debug");
+    assert_from_str(Level::Trace, "trace");
+
+    assert_from_str(Level::Info, "Info");
+    assert_from_str(Level::Info, "INFO");
+    assert_from_str(Level::Info, "iNfO");
+
+    refute_from_str::<Level>("");
+    refute_from_str::<Level>("?");
+    refute_from_str::<Level>("i");
+    refute_from_str::<Level>("info ");
+    refute_from_str::<Level>("informal");
+    refute_from_str::<Level>(" info");
+    refute_from_str::<Level>("desinfo");
+}
+
+#[test]
+fn filter_level_from_str() {
+    assert_from_str(FilterLevel::Off, "off");
+    assert_from_str(FilterLevel::Critical, "critical");
+    assert_from_str(FilterLevel::Error, "error");
+    assert_from_str(FilterLevel::Warning, "warn");
+    assert_from_str(FilterLevel::Info, "info");
+    assert_from_str(FilterLevel::Debug, "debug");
+    assert_from_str(FilterLevel::Trace, "trace");
+
+    assert_from_str(FilterLevel::Info, "Info");
+    assert_from_str(FilterLevel::Info, "INFO");
+    assert_from_str(FilterLevel::Info, "iNfO");
+
+    refute_from_str::<FilterLevel>("");
+    refute_from_str::<FilterLevel>("?");
+    refute_from_str::<FilterLevel>("i");
+    refute_from_str::<FilterLevel>("info ");
+    refute_from_str::<FilterLevel>("informal");
+    refute_from_str::<FilterLevel>(" info");
+    refute_from_str::<FilterLevel>("desinfo");
+}
+
+#[cfg(test)]
+fn assert_from_str<T>(expected: T, level_str: &str)
+    where
+        T: FromStr + fmt::Debug + PartialEq,
+        T::Err: fmt::Debug {
+    let result = T::from_str(level_str);
+
+    let actual = result.unwrap_or_else(|e| {
+        panic!("Failed to parse filter level '{}': {:?}", level_str, e)
+    });
+    assert_eq!(expected, actual, "Invalid filter level parsed from '{}'", level_str);
+}
+
+#[cfg(test)]
+fn refute_from_str<T>(level_str: &str)
+    where
+        T: FromStr + fmt::Debug {
+    let result = T::from_str(level_str);
+
+    if let Ok(level) = result {
+        panic!("Parsing filter level '{}' succeeded: {:?}", level_str, level)
+    }
 }
 // }}}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,6 @@
 // }}}
 
 // {{{ Imports & meta
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 #![warn(missing_docs)]
 #![no_std]
 


### PR DESCRIPTION
- Fixes Level and LevelFilter parsing ignoring length of input
- Fixes Level parsing panicking when input is "off"
- Switch to `str::eq_ignore_ascii_case` while comparing strings ignoring case. It basically does the same (look up table), so performance should be exactly the same, but with no maintenance burden
- Add more level parsing tests
- Remove feature "alloc" when no "std" feature is present. This failed in stable rust (it has no features) and this was stabilized some time ago
- Upgraded Travis Rust from 1.15.1 to 1.23.0 to avoid using deprecated `AsciiExt::eq_ignore_ascii_case`