### PR TITLE
Add converstion to string to FilterLevel, same as Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## ?.?.? - ????-??-??
+
+* Added `as_str`, `as_short_str` and `Display` to `FilterLevel`
+
 ## 2.4.1 - 2018-10-03
 
 * disable support for i128/u128 types if rustc is old

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2135,6 +2135,16 @@ impl Level {
 }
 
 impl FilterLevel {
+    /// Convert to `str` from `LOG_LEVEL_SHORT_NAMES`
+    pub fn as_short_str(&self) -> &'static str {
+        LOG_LEVEL_SHORT_NAMES[self.as_usize()]
+    }
+
+    /// Convert to `str` from `LOG_LEVEL_NAMES`
+    pub fn as_str(&self) -> &'static str {
+        LOG_LEVEL_NAMES[self.as_usize()]
+    }
+
     /// Convert to `usize` value
     ///
     /// `Off` is 0, and `Trace` 6
@@ -2204,6 +2214,12 @@ impl FromStr for FilterLevel {
 }
 
 impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_short_str())
+    }
+}
+
+impl fmt::Display for FilterLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_short_str())
     }


### PR DESCRIPTION
Adds possibility to get FilterLevel text representation. This brings parity with Level.