### PR TITLE
Add FilterLevel::accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## ?.?.? - ????-??-??
 
+* Added `FilterLevel::accepts`
 * Added `as_str`, `as_short_str` and `Display` to `FilterLevel`
 
 ## 2.4.1 - 2018-10-03

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2189,6 +2189,11 @@ impl FilterLevel {
     pub fn min() -> Self {
         FilterLevel::Off
     }
+
+    /// Check if message with given level should be logged
+    pub fn accepts(self, level: Level) -> bool {
+        self.as_usize() >= level.as_usize()
+    }
 }
 
 impl FromStr for Level {
@@ -2315,6 +2320,14 @@ fn refute_from_str<T>(level_str: &str)
     if let Ok(level) = result {
         panic!("Parsing filter level '{}' succeeded: {:?}", level_str, level)
     }
+}
+
+#[test]
+fn filter_level_accepts_tests() {
+    assert_eq!(true, FilterLevel::Warning.accepts(Level::Error));
+    assert_eq!(true, FilterLevel::Warning.accepts(Level::Warning));
+    assert_eq!(false, FilterLevel::Warning.accepts(Level::Info));
+    assert_eq!(false, FilterLevel::Off.accepts(Level::Critical));
 }
 // }}}
 


### PR DESCRIPTION
This method is needed because if user wants to create FilterLevel-based level filter, it's not possible in elegant way:
- LevelFilter is Level-based (would be perfect to extend with FilterLevel support, but it's pretty much deprecated)
- FilterFn gets a Record, which provides only Level, which can't be tested against FilterLevel (yet)
- Level can't be converted to LevelFilter to compare them (but it would be stupid)
- The only way now is to manually use usize representation, which is far from clean or obvious