### PR TITLE
Added parsing of Level and FilterLevel short names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added `FilterLevel::accepts`
 * Added `as_str`, `as_short_str` and `Display` to `FilterLevel`
+* Added parsing of `Level` and `FilterLevel` short names
 
 ## 2.4.1 - 2018-10-03
 


### PR DESCRIPTION
This adds a bit more elasticity to parsers, but most notably brings compatibility between output of `ToString` and input of `FromStr`.

The tests are marked as `feature="std"`, because otherwise I didn't have access to `ToString` and I couldn't capture output of `Display` in memory without allocator.