### PR TITLE
Implement a #? pretty-debug tag for kv-value entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.6.0 - 2019-10-28
+
+* Add #? for pretty-debug printing the value part
+
 ## 2.5.3 - ????-??-??
 
 * Use fully qualified call syntax for `Logger::log` in macros

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog"
-version = "2.5.2"
+version = "2.6.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Structured, extensible, composable logging for Rust"
 keywords = ["log", "logging", "structured", "hierarchical"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,12 @@ macro_rules! kv(
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
         kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
     };
+    (@ $args_ready:expr; $k:expr => #?$v:expr) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
+    };
+    (@ $args_ready:expr; $k:expr => #?$v:expr, $($args:tt)* ) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
+    };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
         kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
     };
@@ -444,6 +450,12 @@ macro_rules! slog_kv(
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
         kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
+    };
+    (@ $args_ready:expr; $k:expr => #?$v:expr) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
+    };
+    (@ $args_ready:expr; $k:expr => #?$v:expr, $($args:tt)* ) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
         slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
@@ -701,7 +713,8 @@ macro_rules! slog_record(
 /// `format_args!("{}", v)`. This is especially useful for errors. Not that
 /// this does not allocate any `String` since it operates on `fmt::Arguments`.
 ///
-/// Similarly to use `std::fmt::Debug` value can be prefixed with `?`.
+/// Similarly to use `std::fmt::Debug` value can be prefixed with `?`,
+/// or pretty-printed with `#?`.
 ///
 /// ```
 /// #[macro_use]
@@ -2738,9 +2751,9 @@ pub trait SerdeValue: erased_serde::Serialize + Value {
 ///
 /// Types that implement this type implement custom serialization in the
 /// structured part of the log macros. Without an implementation of `Value` for
-/// your type you must emit using either the `?` "debug", `%` "display" or
-/// [`SerdeValue`](trait.SerdeValue.html) (if you have the `nested-values`
-/// feature enabled) formatters.
+/// your type you must emit using either the `?` "debug", `#?` "pretty-debug",
+/// `%` "display" or [`SerdeValue`](trait.SerdeValue.html)
+/// (if you have the `nested-values` feature enabled) formatters.
 ///
 /// # Example
 ///


### PR DESCRIPTION
This patch adds the #? "flag" to the value part of the key-value arguments of the logger macros. `#?` simply calls upon `{:#?}` to pretty-print something. This feature would be very useful as I'm sometimes printing rather large structures (from gfx-hal for instance), where readability really counts.

Example usage:
```rust
info!(logger, "Message"; "key" => #?value);
```

Make sure to:

* [X] Add an entry to CHANGELOG.md (if neccessary)
