### PR TITLE
Implemented the "alternate display" formatting prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.7.0 - ????-??-??
+
+* Add #% for alternate display of the value part
+
 ## 2.6.0 - 2019-10-28
 
 * Add #? for pretty-debug printing the value part

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,8 +724,8 @@ macro_rules! slog_record(
 /// `%` in `k => v` expression to use it's text representation returned by
 /// `format_args!("{}", v)`. This is especially useful for errors. Not that
 /// this does not allocate any `String` since it operates on `fmt::Arguments`.
-/// You can also use the `#%` prefix to switch to the "alternate" form, represented
-/// by the `{:#}` formatting specifier.
+/// You can also use the `#%` prefix to use the "alternate" form of formatting,
+/// represented by the `{:#}` formatting specifier.
 ///
 /// Similarly to use `std::fmt::Debug` value can be prefixed with `?`,
 /// or pretty-printed with `#?`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,12 @@ macro_rules! kv(
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
         kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); $($args)* )
     };
+    (@ $args_ready:expr; $k:expr => #%$v:expr) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); )
+    };
+    (@ $args_ready:expr; $k:expr => #%$v:expr, $($args:tt)* ) => {
+        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); $($args)* )
+    };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
         kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); )
     };
@@ -445,17 +451,23 @@ macro_rules! slog_kv(
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
         slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); $($args)* )
     };
+    (@ $args_ready:expr; $k:expr => #%$v:expr) => {
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); )
+    };
+    (@ $args_ready:expr; $k:expr => #%$v:expr, $($args:tt)* ) => {
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); $($args)* )
+    };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); )
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => #?$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => #?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
+        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
         slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
@@ -712,6 +724,8 @@ macro_rules! slog_record(
 /// `%` in `k => v` expression to use it's text representation returned by
 /// `format_args!("{}", v)`. This is especially useful for errors. Not that
 /// this does not allocate any `String` since it operates on `fmt::Arguments`.
+/// You can also use the `#%` prefix to switch to the "alternate" form, represented
+/// by the `{:#}` formatting specifier.
 ///
 /// Similarly to use `std::fmt::Debug` value can be prefixed with `?`,
 /// or pretty-printed with `#?`.
@@ -2752,7 +2766,7 @@ pub trait SerdeValue: erased_serde::Serialize + Value {
 /// Types that implement this type implement custom serialization in the
 /// structured part of the log macros. Without an implementation of `Value` for
 /// your type you must emit using either the `?` "debug", `#?` "pretty-debug",
-/// `%` "display" or [`SerdeValue`](trait.SerdeValue.html)
+/// `%` "display", `#%` "alternate display" or [`SerdeValue`](trait.SerdeValue.html)
 /// (if you have the `nested-values` feature enabled) formatters.
 ///
 /// # Example


### PR DESCRIPTION
Closes #247 

I also fixed a seemingly copy-paste-related mistype in the `slog_kv` macro, I can roll it back if you think it is unnecessary.

---

Make sure to:

* [x] Add an entry to CHANGELOG.md (if neccessary)