### PR TITLE
Impl Fq for dynamic::Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.7.0 - ????-??-??
 
 * Add #% for alternate display of the value part
+* Implement `Eq` for dynamic `Key`s
 
 ## 2.6.0 - 2019-10-28
 

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -41,7 +41,7 @@ use std::string::ToString;
 ///
 /// It is owned, and largely forms a contract for
 /// key to follow.
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 pub struct Key {
     data: Cow<'static, str>,
 }

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -164,6 +164,12 @@ impl PartialEq<str> for Key {
     }
 }
 
+impl PartialEq<&str> for Key {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_ref().eq(*other)
+    }
+}
+
 impl PartialEq<String> for Key {
     fn eq(&self, other: &String) -> bool {
         self.as_ref().eq(other.as_str())

--- a/src/key/dynamic_nostd.rs
+++ b/src/key/dynamic_nostd.rs
@@ -16,7 +16,7 @@ use core::fmt;
 ///
 /// It is owned, and largely forms a contract for
 /// key to follow.
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 pub struct Key {
     data: Cow<'static, str>
 }

--- a/src/key/dynamic_nostd.rs
+++ b/src/key/dynamic_nostd.rs
@@ -126,6 +126,13 @@ impl PartialEq<str> for Key {
     }
 }
 
+impl PartialEq<&str> for Key {
+    #[inline(always)]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_ref().eq(*other)
+    }
+}
+
 impl PartialEq<String> for Key {
     #[inline(always)]
     fn eq(&self, other: &String) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -320,3 +320,10 @@ fn test_never_type_clone() {
     }
     // Always pass if we compiled
 }
+
+#[test]
+fn can_hash_keys() {
+    use std::collections::HashSet;
+    use Key;
+    let tab: HashSet<Key> = ["foo"].iter().map(|&k| k.into()).collect();
+}


### PR DESCRIPTION
This PR implements `Eq` for the dynamic Key variant, which ensures they can be put in stdlib hashes. (I need this in a slog drain). I've also taken the liberty of impl'ing `PartialEq` with `&str` for these Keys also - the original implementation didn't quite catch all the `==` scenarios exposed in tests, at least.

Hope this looks acceptable to you all!