### PR TITLE
Alias slog::Never to std::convert::Infailable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3574,13 +3574,7 @@ impl core::fmt::Display for Error {
 /// rust during time of the release. It will be switched to `!` at some point
 /// and `Never` should not be considered "stable" API.
 #[doc(hidden)]
-pub type Never = private::NeverStruct;
-
-mod private {
-    #[doc(hidden)]
-    #[derive(Clone, Debug)]
-    pub struct NeverStruct(());
-}
+pub type Never = std::convert::Infallible;
 
 /// This is not part of "stable" API
 #[doc(hidden)]


### PR DESCRIPTION
Fixes #209

Both types are simply stable substitutes for the never type.
We just alias the standard library for consistency.

Do we really need to add an entry to the changelog for this? It's basically an implementation detail......
