### PR TITLE
Fix `no_std` build failure with `dynamic_keys` feature

### DIFF
--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -1,11 +1,7 @@
 #[cfg(not(feature = "std"))]
-use alloc::Clone;
-#[cfg(not(feature = "std"))]
-use alloc::String;
-#[cfg(not(feature = "std"))]
 use alloc::borrow::Cow;
 #[cfg(not(feature = "std"))]
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 #[cfg(not(feature = "std"))]
 use core::cmp::PartialEq;
 #[cfg(not(feature = "std"))]

--- a/src/key/dynamic_nostd.rs
+++ b/src/key/dynamic_nostd.rs
@@ -1,8 +1,5 @@
-
-use alloc::String;
 use alloc::borrow::Cow;
-use alloc::Clone;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 
 use core::convert::{From,Into,AsRef};
 use core::ops::Deref;


### PR DESCRIPTION
Two problems:
`alloc::Clone` is not a thing, `Clone` is part of core, and it is
in the prelude.
`alloc::String` is not a thing, it is `alloc::string::String`.