### PR TITLE
std::error::Error support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add #% for alternate display of the value part
 * Implement `Eq` for dynamic `Key`s
+* Add `emit_error` to `Serializer`, `#` for serializing foreign errors, and
+  `impl Value for std::io::Error`
 
 ## 2.6.0 - 2019-10-28
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -205,6 +205,7 @@ fn expressions_fmt() {
     info!(log, "message"; "f" => %f, "d" => ?d);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn display_and_alternate_display() {
     use core::fmt;
@@ -321,6 +322,7 @@ fn test_never_type_clone() {
     // Always pass if we compiled
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn can_hash_keys() {
     use std::collections::HashSet;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -233,20 +233,22 @@ fn display_and_alternate_display() {
         fn log(&self, record: &Record, values: &OwnedKVList) -> Result<(), Never> {
             let mut checked_n = false;
             let mut checked_a = false;
-            let mut serializer = AsFmtSerializer(|key, fmt_args| {
-                if key == "n" {
-                    assert_eq!(format!("{}", fmt_args), "normal");
-                    checked_n = true;
-                } else if key == "a" {
-                    assert_eq!(format!("{}", fmt_args), "alternate");
-                    checked_a = true;
-                } else {
-                    panic!("Unexpected key: {}", key);
-                }
-                Ok(())
-            });
+            {
+                let mut serializer = AsFmtSerializer(|key, fmt_args| {
+                    if key == "n" {
+                        assert_eq!(format!("{}", fmt_args), "normal");
+                        checked_n = true;
+                    } else if key == "a" {
+                        assert_eq!(format!("{}", fmt_args), "alternate");
+                        checked_a = true;
+                    } else {
+                        panic!("Unexpected key: {}", key);
+                    }
+                    Ok(())
+                });
 
-            record.kv.serialize(record, &mut serializer).unwrap();
+                record.kv.serialize(record, &mut serializer).unwrap();
+            }
 
             assert!(checked_n, "Expected the normal formatter to be used");
             assert!(checked_a, "Expected the alternate formatter to be used");


### PR DESCRIPTION
Explicit support for `std::error::Error`

This change implements support for `std::error::Error`, which is a
popular trait used for errors. Since people usually log errors, it makes
sense to support them directly.

Changes include:

* Adding `emit_error()` method to `Serializer`
* Adding a default implementation for `emit_error()`
* Adding a helper wrapper struct for serializing foreign types that
  don't impl `slog::Value` but do impl `std::error::Error`
* Adding `#` prefix to macro, so that the wrapper can be instantiated
  easily
* Adding `impl Value for std::io::Error`
* Adding tests

Closes #273

Make sure to:

* [x] Add an entry to CHANGELOG.md (if neccessary)

This is a preview and the compatibility of `#` was not deeply inspected yet. I'm going to do it soon, just wanted to show my changes soon.

This also contains a commit fixing compilation of `no_std` tests.