### PR TITLE
Make Level/FilterLevel hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.7.0 - ????-??-??
 
-* Implement `Hash` for dynamic `Level` and `FilterLevel`
+* Implement `Hash` for `Level` and `FilterLevel`
 * Add #% for alternate display of the value part
 * Implement `Eq` for dynamic `Key`s
 * Add `emit_error` to `Serializer`, `#` for serializing foreign errors, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.7.0 - ????-??-??
 
+* Implement `Hash` for dynamic `Level` and `FilterLevel`
 * Add #% for alternate display of the value part
 * Implement `Eq` for dynamic `Key`s
 * Add `emit_error` to `Serializer`, `#` for serializing foreign errors, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2086,7 +2086,7 @@ pub static LOG_LEVEL_SHORT_NAMES: [&'static str; 7] =
     ["OFF", "CRIT", "ERRO", "WARN", "INFO", "DEBG", "TRCE"];
 
 /// Logging level associated with a logging `Record`
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Level {
     /// Critical
     Critical,
@@ -2103,7 +2103,7 @@ pub enum Level {
 }
 
 /// Logging filtering level
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum FilterLevel {
     /// Log nothing
     Off,


### PR DESCRIPTION
Useful to derive `Hash` when `Level` or `FilterLevel` are used in other types. 