### PR TITLE
Add `Value` implementation for `std::borrow::Cow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Next
 
 * Fix `#` format when not used as a last argument.
+* Implement `Value` for `std::borrow::Cow`
 
 ## 2.7.0 - 2020-11-29
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,8 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::borrow::{Cow, ToOwned};
 
 #[cfg(feature = "nested-values")]
 extern crate erased_serde;
@@ -335,6 +337,8 @@ use std::rc::Rc;
 use std::string::String;
 #[cfg(feature = "std")]
 use std::sync::Arc;
+#[cfg(feature = "std")]
+use std::borrow::{Cow, ToOwned};
 // }}}
 
 // {{{ Macros
@@ -3017,6 +3021,21 @@ where
         self.0.serialize(record, key, serializer)
     }
 }
+
+impl<'a, T> Value for Cow <'a, T>
+where
+    T: Value + ToOwned + ?Sized,
+{
+    fn serialize(
+        &self,
+        record: &Record,
+        key: Key,
+        serializer: &mut Serializer,
+    ) -> Result {
+        (**self).serialize(record, key, serializer)
+    }
+}
+
 
 #[cfg(feature = "std")]
 impl<'a> Value for std::path::Display<'a> {


### PR DESCRIPTION
It might be useful to have `Value` implemented for `std::borrow::Cow`, for example when values come from either `String` or `&'static str` (in my case 99% of values is small set of strings, and for optimization reasons I store them as `&'static str` inside binary).

Make sure to:

* [x] Add an entry to CHANGELOG.md (if neccessary)
