### PR TITLE
Explicitly document the minimum supported rust version (MSRV)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,20 @@ repository = "https://github.com/slog-rs/slog"
 readme = "README.md"
 autoexamples = true
 
+# This is our Minimum Supported Rust Version (MSRV)
+#
+# See the wiki for our full policy on changing this.
+#
+# There are two main requirements:
+# 1. Bumping the MSRV requires increasing the minor version number (2.7 -> 2.8)
+# 2. Changes must be clearly announced in the CHANGELOG.md file
+# 3. At a minimum, we must support at least the latest stable rust, minus two releases. 
+#    - We can (and very often do) supprot versions much older than this
+#
+# The first version of Cargo that supports this field was released with Rust 1.56.0.
+# In older releases, the field will be ignored, and Cargo will display a warning.
+rust-version = "1.23"
+
 build = "build.rs"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ autoexamples = true
 # There are two main requirements:
 # 1. Bumping the MSRV requires increasing the minor version number (2.7 -> 2.8)
 # 2. Changes must be clearly announced in the CHANGELOG.md file
-# 3. At a minimum, we must support at least the latest stable rust, minus two releases. 
-#    - We can (and very often do) supprot versions much older than this
+# 3. At a minimum, we must support at least the latest stable rust, minus 15 releases.
+#    - We can (and very often do) support versions much older than this.
+#    - See wiki for for details
 #
-# The first version of Cargo that supports this field was released with Rust 1.56.0.
+# The first version of Cargo that supports this field was in Rust 1.56.0.
 # In older releases, the field will be ignored, and Cargo will display a warning.
 rust-version = "1.23"
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
   <a href="https://docs.rs/releases/search?query=slog-">
       <img src="https://docs.rs/slog/badge.svg" alt="docs-rs: release versions documentation">
   </a>
+  <a href="https://blog.rust-lang.org/2018/01/04/Rust-1.23.html">
+      <img src="https://img.shields.io/badge/rust-1.23%2B-orange.svg">
+  </a>
   <br>
     <strong><a href="https://github.com/slog-rs/slog/wiki/Getting-started">Getting started</a></strong>
   <a href="//github.com/slog-rs/slog/wiki/Introduction-to-structured-logging-with-slog">Introduction</a>


### PR DESCRIPTION
Currently, the minimum supported rust version (MSRV) is 1.23.

The full policy for changing the version is available on the Wiki.

The shields.io badge is inspired by serde and indexmap project.

Before this commit, the MSRV was unofficially present in the travis.yml file

To be clear, I have not changed the version and I have not 
changed any policies.

I have only documented and summarized what has already existed.

Make sure to:

* [ ] ~Add an entry to CHANGELOG.md (if necessary)~
     - Should not be applicable as this change only affects the documentation and clarifies what has already existed
