### PR TITLE
Use a single trait def for every feature combination, fixing all the broken tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **BIG:** Updated to Rust 2018
   * Minimum supported Rust Version is now 1.31
   * NOTE: Old 2015 crates will still work because of [excellent 2015/2018 compatibility](https://blog.rust-lang.org/2018/07/27/what-is-rust-2018.html#managing-compatibility)
+* Fix support for `feature="nothreads"`
+  * Internal refactoring to make different feature combos much easier (PR #301)
 * Switch from Travis CI to Github Actions (fixes #294)
   * `rustfmt --check` now run by default
 * Fix `#` format when not used as a last argument.

--- a/examples/singlethread.rs
+++ b/examples/singlethread.rs
@@ -1,4 +1,4 @@
-//#![feature(nothreads)]
+#![cfg(feature = "nothreads")]
 use slog::{info, o, Fuse, Logger};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -9,6 +9,7 @@ mod common;
 struct NoThreadSafeObject {
     val: Rc<RefCell<usize>>,
 }
+impl std::panic::RefUnwindSafe for NoThreadSafeObject {}
 
 fn main() {
     let log = Logger::root(Fuse(common::PrintlnDrain), o!("version" => "2"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1568,10 +1568,10 @@ impl<'a, D: Drain + 'a> Drain for &'a mut D {
 ///
 /// This avoids quadrupling trait definitions for every possible feature combination.
 mod maybe {
-    #[cfg(feature = "std")]
-    use std::panic;
     #[cfg(not(feature = "nothreads"))]
     use core::marker;
+    #[cfg(feature = "std")]
+    use std::panic;
     macro_rules! maybe_bound_trait_def {
         ($name:ident where $bound:path; if cfg($flag:meta)) => {
             #[cfg($flag)]
@@ -1582,7 +1582,6 @@ mod maybe {
             pub trait $name {}
             #[cfg(not($flag))]
             impl<T: ?Sized> $name for T {}
-
         };
     }
     maybe_bound_trait_def!(UnwindSafe where panic::UnwindSafe; if cfg(feature="std"));
@@ -1595,15 +1594,24 @@ mod maybe {
 ///
 /// This type is used to enforce `Drain`s associated with `Logger`s
 /// are thread-safe.
-pub trait SendSyncUnwindSafe: maybe::Send + maybe::Sync + maybe::UnwindSafe {}
+pub trait SendSyncUnwindSafe:
+    maybe::Send + maybe::Sync + maybe::UnwindSafe
+{
+}
 
-impl<T> SendSyncUnwindSafe for T where T: maybe::Send + maybe::Sync + maybe::UnwindSafe + ?Sized {}
+impl<T> SendSyncUnwindSafe for T where
+    T: maybe::Send + maybe::Sync + maybe::UnwindSafe + ?Sized
+{
+}
 
 /// `Drain + Send + Sync + UnwindSafe` bound
 ///
 /// This type is used to enforce `Drain`s associated with `Logger`s
 /// are thread-safe.
-pub trait SendSyncUnwindSafeDrain: Drain + maybe::Send + maybe::Sync + maybe::UnwindSafe {}
+pub trait SendSyncUnwindSafeDrain:
+    Drain + maybe::Send + maybe::Sync + maybe::UnwindSafe
+{
+}
 
 impl<T> SendSyncUnwindSafeDrain for T where
     T: Drain + maybe::Send + maybe::Sync + maybe::UnwindSafe + ?Sized
@@ -1626,7 +1634,12 @@ impl<T> SendSyncRefUnwindSafeDrain for T where
 
 /// Function that can be used in `MapErr` drain
 pub trait MapErrFn<EI, EO>:
-    'static + maybe::Sync + maybe::Send + maybe::UnwindSafe + maybe::RefUnwindSafe + Fn(EI) -> EO
+    'static
+    + maybe::Sync
+    + maybe::Send
+    + maybe::UnwindSafe
+    + maybe::RefUnwindSafe
+    + Fn(EI) -> EO
 {
 }
 
@@ -1643,7 +1656,12 @@ impl<T, EI, EO> MapErrFn<EI, EO> for T where
 
 /// Function that can be used in `Filter` drain
 pub trait FilterFn:
-    'static + maybe::Sync + maybe::Send + maybe::UnwindSafe + maybe::RefUnwindSafe + Fn(&Record<'_>) -> bool
+    'static
+    + maybe::Sync
+    + maybe::Send
+    + maybe::UnwindSafe
+    + maybe::RefUnwindSafe
+    + Fn(&Record<'_>) -> bool
 {
 }
 
@@ -1659,7 +1677,10 @@ impl<T> FilterFn for T where
 }
 
 /// `Drain + Send + RefUnwindSafe` bound
-pub trait SendRefUnwindSafeDrain: Drain + maybe::Send + maybe::RefUnwindSafe {}
+pub trait SendRefUnwindSafeDrain:
+    Drain + maybe::Send + maybe::RefUnwindSafe
+{
+}
 
 impl<T> SendRefUnwindSafeDrain for T where
     T: Drain + maybe::Send + maybe::RefUnwindSafe + ?Sized
@@ -3331,9 +3352,15 @@ where
 /// Thread-local safety bound for `KV`
 ///
 /// This type is used to enforce `KV`s stored in `Logger`s are thread-safe.
-pub trait SendSyncRefUnwindSafeKV: KV + maybe::Send + maybe::Sync + maybe::RefUnwindSafe {}
+pub trait SendSyncRefUnwindSafeKV:
+    KV + maybe::Send + maybe::Sync + maybe::RefUnwindSafe
+{
+}
 
-impl<T> SendSyncRefUnwindSafeKV for T where T: KV + maybe::Send + maybe::Sync + maybe::RefUnwindSafe + ?Sized {}
+impl<T> SendSyncRefUnwindSafeKV for T where
+    T: KV + maybe::Send + maybe::Sync + maybe::RefUnwindSafe + ?Sized
+{
+}
 
 /// Single pair `Key` and `Value`
 pub struct SingleKV<V>(pub Key, pub V)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@ macro_rules! slog_record(
 ///                     _record: &Record,
 ///                     serializer: &mut dyn Serializer)
 ///                    -> Result {
-///            serializer.emit_u32("MyK", 16)
+///            serializer.emit_u32("MyK".into(), 16)
 ///        }
 ///     }
 ///
@@ -703,7 +703,7 @@ macro_rules! slog_record(
 ///                     key : Key,
 ///                     serializer: &mut dyn Serializer)
 ///                    -> Result {
-///            serializer.emit_u32("MyKV", 16)
+///            serializer.emit_u32("MyKV".into(), 16)
 ///        }
 ///     }
 ///
@@ -3306,7 +3306,7 @@ where
 ///
 /// impl KV for MyNewType {
 ///    fn serialize(&self, _rec: &Record, serializer: &mut dyn Serializer) -> Result {
-///        serializer.emit_i64("my_new_type", self.0)
+///        serializer.emit_i64("my_new_type".into(), self.0)
 ///    }
 /// }
 /// ```

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,14 +43,13 @@ mod std_only {
                 ) -> Result {
                     use core::fmt::Write;
 
-                    match key {
-                        "error" => self.0.write_fmt(*val).unwrap(),
-                        _ => {
-                            self.0.write_str(&key).unwrap();
-                            self.0.write_str(": ").unwrap();
-                            self.0.write_fmt(*val).unwrap();
-                            self.0.write_str("; ").unwrap();
-                        }
+                    if key == "error" {
+                        self.0.write_fmt(*val)?;
+                    } else {
+                        self.0.write_str(key.as_ref())?;
+                        self.0.write_str(": ")?;
+                        self.0.write_fmt(*val)?;
+                        self.0.write_str("; ")?;
                     }
                     Ok(())
                 }


### PR DESCRIPTION
This fixes all the test failures for every possible feature combination,
many of which wouldn't even compile before this change.

Fixing `feature="nothreads"` was especially hard, and required
a relatively big refactoring (see below)

## Use a single trait definition for every possible feature combination
Before this change, we had to use multiple trait definitions for every
possible combination of std/no\_std and threads/nothreads

This requires 4x as many trait definitions as default features.

As you can immaigne, we've been forgetting some of these :wink:

This fixes it by creating an internal utility module of `maybe` traits,
which are automatically enabled/disabled depending on the features.

So `Sync` becomes `maybe::Sync` and `UnwindSafe` becomes `maybe::UnwindSafe`

This commit fixes the tests for feature="nothreads", and also `no\_std + nothreads`
and probably a bunch of other bugs too.

Now we are able to support every possible feature combo
without quadrupling trait defintiions ;)
