### PR TITLE
Fix inconsistent 'long' name for Level::Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix `#` format when not used as a last argument.
 * Implement `Value` for `std::borrow::Cow`
 * Fix duplicate `AsRef<str>` implementations, fixing support for `dynamic-keys`
+* Fix incorrect 'long' name for `slog::Level::Warning` (fixes issue #282)
 
 ## 2.7.0 - 2020-11-29
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2090,8 +2090,9 @@ impl<D: Drain> Drain for std::sync::Mutex<D> {
 /// Official capitalized logging (and logging filtering) level names
 ///
 /// In order of `as_usize()`.
-pub static LOG_LEVEL_NAMES: [&str; 7] =
-    ["OFF", "CRITICAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+pub static LOG_LEVEL_NAMES: [&str; 7] = [
+    "OFF", "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE",
+];
 
 /// Official capitalized logging (and logging filtering) short level names
 ///


### PR DESCRIPTION
Thanks to @Jonathas-Conceicao for discovering this :)

Fixes #282

Make sure to:

* [ ] Add an entry to CHANGELOG.md (if necessary)
