### PR TITLE
Add `ErrorRef` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Add `ErrorRef` wrapper to enable logging error references.
+
 ### 2.8.0-beta.1 - 2023-09-09
 
 * **BIG:** Updated to Rust 2018

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3357,6 +3357,8 @@ where
 ///
 /// This struct is only available in `std` because the `Error` trait is not available
 /// without `std`.
+///
+/// Use [`ErrorRef`] if you have an error reference.
 #[cfg(feature = "std")]
 pub struct ErrorValue<E: std::error::Error>(pub E);
 
@@ -3372,6 +3374,34 @@ where
         serializer: &mut dyn Serializer,
     ) -> Result {
         serializer.emit_error(key, &self.0)
+    }
+}
+
+/// A wrapper struct for serializing errors references.
+///
+/// This struct can be used to wrap types that don't implement `slog::Value` but
+/// do implement `std::error::Error` so that they can be logged.
+/// This is usually not used directly but using `#error` in the macros.
+///
+/// This struct is only available in `std` because the `Error` trait is not available
+/// without `std`.
+///
+/// Use [`ErrorValue`] if you want to move ownership of the error value.
+#[cfg(feature = "std")]
+pub struct ErrorRef<'a, E: std::error::Error>(pub &'a E);
+
+#[cfg(feature = "std")]
+impl<'a, E> Value for ErrorRef<'a, E>
+where
+    E: 'static + std::error::Error,
+{
+    fn serialize(
+        &self,
+        _record: &Record<'_>,
+        key: Key,
+        serializer: &mut dyn Serializer,
+    ) -> Result {
+        serializer.emit_error(key, self.0)
     }
 }
 


### PR DESCRIPTION
This commit adds the `ErrorRef` wrapper type. It enables to log error by reference, without moving ownership. It means that it is the non-owning counterpart of `ErrorValue`.

Logging error references is an important use case for transparent logging middlewares. With this wrapper type, you can log the error and still pass it up the call stack.

Such a wrapper type could already easily be implemented in user applications, but having it as part of Slog should help ergonomics. This also enables further improvements by integrating it with the Slog macros.

Closes slog-rs/slog#288

Make sure to:

* [x] Add an entry to CHANGELOG.md (if necessary)
