### PR TITLE
Support `ErrorRef` in `#` error formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-* Add `ErrorRef` wrapper to enable logging error references.
-  * The `#` error formatter in macros was updated to automatically select `ErrorValue` or `ErrorRef`.
+* Add `ErrorRef` wrapper to enable logging error references (PR #327)
+  * The `#` error formatter in macros was updated to automatically select `ErrorValue` or `ErrorRef` (PR #328)
 
 ### 2.8.0-beta.1 - 2023-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 * Add `ErrorRef` wrapper to enable logging error references.
+  * The `#` error formatter in macros was updated to automatically select `ErrorValue` or `ErrorRef`.
 
 ### 2.8.0-beta.1 - 2023-09-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,14 +69,15 @@ release_max_level_trace = []
 erased-serde = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
+
+[dev-dependencies]
 # NOTE: This is just a macro (not a runtime dependency)
 #
 # It is used to conditionally enable use of newer rust language
 # features depending on the compiler features.
-# Currently, this is not needed because our MSRV is sufficient
-# for all the features we use.
-# However, in the future we may need to re-add it.
-# rustversion = "1"
+#
+# For the time being, this is only needed for tests.
+rustversion = "1"
 
 [[example]]
 name = "singlethread"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3438,7 +3438,7 @@ pub struct ErrorRefTag;
 #[cfg(feature = "std")]
 impl ErrorRefTag {
     /// Create a [`Value`] wrapper for an error reference.
-    pub fn wrap<'a, E>(self, e: &'a E) -> ErrorRef<'a, E>
+    pub fn wrap<E>(self, e: &E) -> ErrorRef<'_, E>
     where
         E: ?Sized + 'static + std::error::Error,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3388,7 +3388,14 @@ fn test_error_tag_wrapper() {
     }
     impl std::error::Error for MyError {}
     let e = MyError("everything is on fire");
-    assert_eq!((&&ErrorTagWrapper(e)).slog_error_kind(), ErrorValueTag);
+    assert_eq!(
+        {
+            #[allow(clippy::needless_borrow)]
+            // The "needless" borrow is part of the point
+            (&&ErrorTagWrapper(e)).slog_error_kind()
+        },
+        ErrorValueTag
+    );
     let e = &e;
     assert_eq!((&&ErrorTagWrapper(e)).slog_error_kind(), ErrorRefTag);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -133,6 +133,30 @@ mod std_only {
     }
 
     #[test]
+    fn error_ref() {
+        let error = TestError::new("foo");
+        let error = &error;
+        let logger = Logger::root(CheckError, o!());
+        info!(logger, "foo"; "error" => #error);
+    }
+
+    #[test]
+    fn error_box_ref() {
+        let error = TestError::new("foo");
+        let error = Box::new(error);
+        let logger = Logger::root(CheckError, o!());
+        info!(logger, "foo"; "error" => #&error);
+    }
+
+    #[test]
+    fn error_arc_ref() {
+        let error = TestError::new("foo");
+        let error = Arc::new(error);
+        let logger = Logger::root(CheckError, o!());
+        info!(logger, "foo"; "error" => #&error);
+    }
+
+    #[test]
     fn error_fmt_no_source() {
         let logger =
             Logger::root(CheckError, o!("error" => #TestError::new("foo")));
@@ -145,8 +169,8 @@ mod std_only {
         let error = TestError::new("foo");
         let error = &error;
         let logger = Logger::root(CheckError, o!());
-        info!(logger, "foo"; "error" => ErrorRef(error));
-        slog_info!(logger, "foo"; "error" => ErrorRef(error));
+        info!(logger, "foo"; "error" => #error);
+        slog_info!(logger, "foo"; "error" => #error);
     }
 
     #[test]
@@ -164,8 +188,8 @@ mod std_only {
         let error = TestError::new("foo");
         let error = &error;
         let logger = Logger::root(CheckError, o!());
-        info!(logger, "not-error: not-error; foo"; "error" => ErrorRef(error), "not-error" => "not-error");
-        slog_info!(logger, "not-error: not-error; foo"; "error" => ErrorRef(error), "not-error" => "not-error");
+        info!(logger, "not-error: not-error; foo"; "error" => #error, "not-error" => "not-error");
+        slog_info!(logger, "not-error: not-error; foo"; "error" => #error, "not-error" => "not-error");
     }
 
     #[test]
@@ -183,8 +207,8 @@ mod std_only {
         let error = TestError::new("foo");
         let error = &error;
         let logger = Logger::root(CheckError, o!());
-        info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => ErrorRef(error));
-        slog_info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => ErrorRef(error));
+        info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => #error);
+        slog_info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => #error);
     }
 
     #[test]
@@ -202,8 +226,8 @@ mod std_only {
         let error = TestError("foo", Some(TestError::new("bar")));
         let error = &error;
         let logger = Logger::root(CheckError, o!());
-        info!(logger, "foo: bar"; "error" => ErrorRef(error));
-        slog_info!(logger, "foo: bar"; "error" => ErrorRef(error));
+        info!(logger, "foo: bar"; "error" => #error);
+        slog_info!(logger, "foo: bar"; "error" => #error);
     }
 
     #[test]
@@ -224,8 +248,8 @@ mod std_only {
         );
         let error = &error;
         let logger = Logger::root(CheckError, o!());
-        info!(logger, "foo: bar: baz"; "error" => ErrorRef(error));
-        slog_info!(logger, "foo: bar: baz"; "error" => ErrorRef(error));
+        info!(logger, "foo: bar: baz"; "error" => #error);
+        slog_info!(logger, "foo: bar: baz"; "error" => #error);
     }
 
     #[test]
@@ -234,7 +258,8 @@ mod std_only {
         info!(logger, "not found"; "error" => std::io::Error::from(std::io::ErrorKind::NotFound));
         // compiles?
         info!(logger, "not found"; "error" => #std::io::Error::from(std::io::ErrorKind::NotFound));
-        info!(logger, "not found"; "error" => ErrorRef(&std::io::Error::from(std::io::ErrorKind::NotFound)));
+        let error = std::io::Error::from(std::io::ErrorKind::NotFound);
+        info!(logger, "not found"; "error" => #&error);
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -148,6 +148,8 @@ mod std_only {
         info!(logger, "foo"; "error" => #&error);
     }
 
+    // requires `impl Error for Arc<T>` - since 1.52
+    #[rustversion::since(1.52)]
     #[test]
     fn error_arc_ref() {
         let error = TestError::new("foo");


### PR DESCRIPTION
This commit adds support for error references for the `#` error formatter from the `kv` macro. If the passed error is an owned error value it uses `ErrorValue`; otherwise if it can be dereferenced into an error then it uses `ErrorRef`.

The way to detect if the value implements `Error` directly or if it's an error reference is based on auto-deref coercion as described in the following articles:
- <https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html>
- <https://github.com/dtolnay/case-studies/tree/master/autoref-specialization>

I believe it to be fully backwards compatible with existing uses of `#`. This provides a short-hand for the `ErrorRef` wrapper in most common cases. However, it does not support temporary lifetime extension.

This means that the following example needs to introduce a temporary binding to use the shorthand syntax:
```rust
// explicit ref with lifetime extension
info!(logger, "not found"; "error" => ErrorRef(&std::io::Error::from(std::io::ErrorKind::NotFound)));
// `#` shorthand with temporary binding
let error = std::io::Error::from(std::io::ErrorKind::NotFound);
info!(logger, "not found"; "error" => #&error);
```

In practice, this use case is not an issue. Such a temporary can instead be passed by value (the reference is useless) through `ErrorValue`. There are [discussions in Zulip](https://rust-lang.zulipchat.com/#narrow/stream/403629-t-lang.2Ftemporary-lifetimes-2024) to support explicit lifetime extensions and support this use case in the future.

Make sure to:

* [x] Add an entry to CHANGELOG.md (if necessary)

This is a follow up to https://github.com/slog-rs/slog/pull/327 to add support for the macro shorthand `#`. I sent it in its own PR as the logic is more complex and I don't want to block the simple error reference wrapper because of the macro logic. [Commit with macro support](https://github.com/slog-rs/slog/pull/328/commits/e2a25e90225c1e83b36451b3547d6d925182864b)