### PR TITLE
Bump version to 2.8.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### 2.8.0-beta.2 - 2024-01-05
+
 * Add `ErrorRef` wrapper to enable logging error references (PR #327)
   * The `#` error formatter in macros was updated to automatically select `ErrorValue` or `ErrorRef` (PR #328)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog"
-version = "2.8.0-beta.1"
+version = "2.8.0-beta.2"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Structured, extensible, composable logging for Rust"
 keywords = ["log", "logging", "structured", "hierarchical"]


### PR DESCRIPTION
I still want to make some improvements before I release the full `2.8.0`. I am planning to (slightly) cleanup the macros.

The primary change in this release is the `ErrorRef` PR.