### PR TITLE
Give warnings when using old `slog_` prefixed macros (ex. `slog_log`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* Deprecate old prefixed macros like `slog_log`.
+  Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
+  * This change can be applied automatically by running `sed -E 's/(slog::)?slog_(\w+[!])/slog::\2/' {files}`,
+    which is how I converted the slog tests.
 
 ### 2.8.0-rc.1 - 2025-08-06
-
 * Minimum Supported Rust Version is now [1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/).
   This was already required if you wanted to use the `nested-values` feature. 
 * Take advantage of the fact that in 1.81 [`std::error::Error`] has been moved to `core`.

--- a/crates/test_edition2018/lib.rs
+++ b/crates/test_edition2018/lib.rs
@@ -1,6 +1,8 @@
 #![allow(
     // part of the tests
     named_arguments_used_positionally,
+    // don't want to modify old code
+    deprecated,
 )]
 
 #[cfg(test)]
@@ -13,15 +15,15 @@ mod tests {
         let _ = slog::kv!("a" => %"A");
         let _ = slog::kv!("a" => ?"A");
 
-        let _ = slog::slog_kv!("a" => "A");
-        let _ = slog::slog_kv!("a" => %"A");
-        let _ = slog::slog_kv!("a" => ?"A");
+        let _ = slog::kv!("a" => "A");
+        let _ = slog::kv!("a" => %"A");
+        let _ = slog::kv!("a" => ?"A");
 
         // checks if `local_inner_macros` works correctly.
         let _ = slog::o!("a" => "A");
         let _ = slog::b!("a" => "A");
-        let _ = slog::slog_o!("a" => "A");
-        let _ = slog::slog_b!("a" => "A");
+        let _ = slog::o!("a" => "A");
+        let _ = slog::b!("a" => "A");
     }
 
     #[test]
@@ -34,17 +36,10 @@ mod tests {
         slog::log!(logger, slog::Level::Info, "", "{}{}", a = "A", b = "B");
         slog::log!(logger, slog::Level::Info, "", "{}", a="A"; "id" => 42);
 
-        slog::slog_log!(logger, slog::Level::Info, "", "logger message");
-        slog::slog_log!(logger, slog::Level::Info, "", "{}", 42);
-        slog::slog_log!(
-            logger,
-            slog::Level::Info,
-            "",
-            "{}{}",
-            a = "A",
-            b = "B"
-        );
-        slog::slog_log!(logger, slog::Level::Info, "", "{}", a="A"; "id" => 42);
+        slog::log!(logger, slog::Level::Info, "", "logger message");
+        slog::log!(logger, slog::Level::Info, "", "{}", 42);
+        slog::log!(logger, slog::Level::Info, "", "{}{}", a = "A", b = "B");
+        slog::log!(logger, slog::Level::Info, "", "{}", a="A"; "id" => 42);
 
         // checks if `local_inner_macros` works correctly.
 
@@ -55,11 +50,11 @@ mod tests {
         slog::error!(logger, "message");
         slog::crit!(logger, "message");
 
-        slog::slog_trace!(logger, "message");
-        slog::slog_debug!(logger, "message");
-        slog::slog_info!(logger, "message");
-        slog::slog_warn!(logger, "message");
-        slog::slog_error!(logger, "message");
-        slog::slog_crit!(logger, "message");
+        slog::trace!(logger, "message");
+        slog::debug!(logger, "message");
+        slog::info!(logger, "message");
+        slog::warn!(logger, "message");
+        slog::error!(logger, "message");
+        slog::crit!(logger, "message");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,10 +341,12 @@ macro_rules! o(
 ///
 /// Use in case of macro name collisions
 #[macro_export(local_inner_macros)]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::o!(...) instead"
+)]
 macro_rules! slog_o(
-    ($($args:tt)*) => {
-        $crate::OwnedKV(slog_kv!($($args)*))
-    };
+    ($($args:tt)*) => ($crate::o!($($args)*));
 );
 
 /// Macro for building group of key-value pairs in
@@ -360,11 +362,13 @@ macro_rules! b(
 );
 
 /// Alias of `b`
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::b!(...) instead"
+)]
 macro_rules! slog_b(
-    ($($args:tt)*) => {
-        $crate::BorrowedKV(&slog_kv!($($args)*))
-    };
+    ($($args:tt)*) => ($crate::b!($($args)*));
 );
 
 /// Macro for build `KV` implementing type
@@ -374,34 +378,34 @@ macro_rules! slog_b(
 #[macro_export(local_inner_macros)]
 macro_rules! kv(
     (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); $($args)* )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => #%$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:#}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => #%$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); $($args)* )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:#}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => #?$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:#?}", $v))), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => #?$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => #$v:expr) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@wrap_error $v) )), $args_ready); )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@wrap_error $v) )), $args_ready); )
     };
     (@ $args_ready:expr; $k:expr => #$v:expr, $($args:tt)* ) => {
-        kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@wrap_error $v))), $args_ready); $($args)* )
+        kv!(@ ($crate::SingleKV::from(($k, $crate::__builtin!(@wrap_error $v))), $args_ready); $($args)* )
     };
     (@ $args_ready:expr; $k:expr => $v:expr) => {
         kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
@@ -428,59 +432,13 @@ macro_rules! kv(
 
 /// Alias of `kv`
 // Note: make sure to keep in sync with `kv`
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::kv!(...) instead"
+)]
 macro_rules! slog_kv(
-    (@ $args_ready:expr; $k:expr => %$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => %$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{}", $v))), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $k:expr => #%$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => #%$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#}", $v))), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $k:expr => ?$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => ?$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:?}", $v))), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $k:expr => #?$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => #?$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@format_args "{:#?}", $v))), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $k:expr => #$v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@wrap_error $v) )), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => #$v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, __slog_builtin!(@wrap_error $v) )), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $k:expr => $v:expr) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); )
-    };
-    (@ $args_ready:expr; $k:expr => $v:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($crate::SingleKV::from(($k, $v)), $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; $slog_kv:expr) => {
-        slog_kv!(@ ($slog_kv, $args_ready); )
-    };
-    (@ $args_ready:expr; $slog_kv:expr, $($args:tt)* ) => {
-        slog_kv!(@ ($slog_kv, $args_ready); $($args)* )
-    };
-    (@ $args_ready:expr; ) => {
-        $args_ready
-    };
-    (@ $args_ready:expr;, ) => {
-        $args_ready
-    };
-    ($($args:tt)*) => {
-        slog_kv!(@ (); $($args)*)
-    };
+    ($($args:tt)*) => ($crate::kv!(@ (); $($args)*));
 );
 
 #[macro_export(local_inner_macros)]
@@ -489,11 +447,11 @@ macro_rules! record_static(
     ($lvl:expr, $tag:expr,) => { record_static!($lvl, $tag) };
     ($lvl:expr, $tag:expr) => {{
         static LOC : $crate::RecordLocation = $crate::RecordLocation {
-            file: __slog_builtin!(@file),
-            line: __slog_builtin!(@line),
-            column: __slog_builtin!(@column),
+            file: $crate::__builtin!(@file),
+            line: $crate::__builtin!(@line),
+            column: $crate::__builtin!(@column),
             function: "",
-            module: __slog_builtin!(@module_path),
+            module: $crate::__builtin!(@module_path),
         };
         $crate::RecordStatic {
             location : &LOC,
@@ -503,24 +461,14 @@ macro_rules! record_static(
     }};
 );
 
-#[macro_export(local_inner_macros)]
 /// Create `RecordStatic` at the given code location (alias)
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::record_static!(...) instead"
+)]
 macro_rules! slog_record_static(
-    ($lvl:expr, $tag:expr,) => { slog_record_static!($lvl, $tag) };
-    ($lvl:expr, $tag:expr) => {{
-        static LOC : $crate::RecordLocation = $crate::RecordLocation {
-            file: __slog_builtin!(@file),
-            line: __slog_builtin!(@line),
-            column: __slog_builtin!(@column),
-            function: "",
-            module: __slog_builtin!(@module_path),
-        };
-        $crate::RecordStatic {
-            location : &LOC,
-            level: $lvl,
-            tag: $tag,
-        }
-    }};
+    ($($arg:tt)*) => ($crate::record_static!($($arg)*));
 );
 
 #[macro_export(local_inner_macros)]
@@ -540,17 +488,14 @@ macro_rules! record(
     }};
 );
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::record!(...) instead"
+)]
 /// Create `Record` at the given code location (alias)
 macro_rules! slog_record(
-    ($lvl:expr, $tag:expr, $args:expr, $b:expr,) => {
-        slog_record!($lvl, $tag, $args, $b)
-    };
-    ($lvl:expr, $tag:expr, $args:expr, $b:expr) => {{
-        static RS : $crate::RecordStatic<'static> = slog_record_static!($lvl,
-                                                                        $tag);
-        $crate::Record::new(&RS, $args, $b)
-    }};
+    ($($arg:tt)*) => ($crate::record_static!($($arg)*));
 );
 
 /// Log message a logging record
@@ -749,7 +694,7 @@ macro_rules! slog_record(
 macro_rules! log(
     // `2` means that `;` was already found
    (2 @ { $($fmt:tt)* }, { $($kv:tt)* },  $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr) => {
-      $crate::Logger::log(&$l, &record!($lvl, $tag, &__slog_builtin!(@format_args $msg_fmt, $($fmt)*), b!($($kv)*)))
+      $crate::Logger::log(&$l, &record!($lvl, $tag, &$crate::__builtin!(@format_args $msg_fmt, $($fmt)*), b!($($kv)*)))
    };
    (2 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr,) => {
        log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt)
@@ -763,19 +708,19 @@ macro_rules! log(
     // `1` means that we are still looking for `;`
     // -- handle named arguments to format string
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr) => {
-       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
+       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* $crate::__builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
    };
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr;) => {
-       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
+       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* $crate::__builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
    };
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr,) => {
-       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
+       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* $crate::__builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
    };
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr; $($args:tt)*) => {
-       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
+       log!(2 @ { $($fmt)* $k = $v }, { $($kv)* $crate::__builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
    };
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr, $($args:tt)*) => {
-       log!(1 @ { $($fmt)* $k = $v, }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
+       log!(1 @ { $($fmt)* $k = $v, }, { $($kv)* $crate::__builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
    };
     // -- look for `;` termination
    (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr,) => {
@@ -803,103 +748,56 @@ macro_rules! log(
 
 /// Log message a logging record (alias)
 ///
-/// Prefer [shorter version](macro.log.html), unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
+/// Now it is possible to simply use the prefixed path `slog::log!`.
 ///
 /// See [`log`](macro.log.html) for documentation.
 ///
 /// ```
-/// #[macro_use(slog_o,slog_b,slog_record,slog_record_static,slog_log,slog_info,slog_kv,__slog_builtin)]
+/// #[macro_use(slog_o,slog_b,slog_record,slog_record_static,slog_log,slog_info,slog_kv,$crate_builtin)]
 /// extern crate slog;
 ///
 /// fn main() {
-///     let log = slog::Logger::root(slog::Discard, slog_o!());
+///     let log = slog::Logger::root(slog::Discard, slog::o!());
 ///
-///     slog_info!(log, "some interesting info"; "where" => "right here");
+///     slog::info!(log, "some interesting info"; "where" => "right here");
 /// }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::log!(...) instead"
+)]
 macro_rules! slog_log(
-    // `2` means that `;` was already found
-   (2 @ { $($fmt:tt)* }, { $($kv:tt)* },  $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr) => {
-      $crate::Logger::log(&$l, &slog_record!($lvl, $tag, &__slog_builtin!(@format_args $msg_fmt, $($fmt)*), slog_b!($($kv)*)))
-   };
-   (2 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr,) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (2 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr;) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (2 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $($args:tt)*) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* $($args)*}, $l, $lvl, $tag, $msg_fmt)
-   };
-    // `1` means that we are still looking for `;`
-    // -- handle named arguments to format string
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr) => {
-       slog_log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr;) => {
-       slog_log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr,) => {
-       slog_log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr; $($args:tt)*) => {
-       slog_log!(2 @ { $($fmt)* $k = $v }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $k:ident = $v:expr, $($args:tt)*) => {
-       slog_log!(1 @ { $($fmt)* $k = $v, }, { $($kv)* __slog_builtin!(@stringify $k) => $v, }, $l, $lvl, $tag, $msg_fmt, $($args)*)
-   };
-    // -- look for `;` termination
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr,) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, ; $($args:tt)*) => {
-       slog_log!(1 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt; $($args)*)
-   };
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr; $($args:tt)*) => {
-       slog_log!(2 @ { $($fmt)* }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt, $($args)*)
-   };
-    // -- must be normal argument to format string
-   (1 @ { $($fmt:tt)* }, { $($kv:tt)* }, $l:expr, $lvl:expr, $tag:expr, $msg_fmt:expr, $f:tt $($args:tt)*) => {
-       slog_log!(1 @ { $($fmt)* $f }, { $($kv)* }, $l, $lvl, $tag, $msg_fmt, $($args)*)
-   };
-   ($l:expr, $lvl:expr, $tag:expr, $($args:tt)*) => {
-       if $lvl.as_usize() <= $crate::__slog_static_max_level().as_usize() {
-           slog_log!(1 @ { }, { }, $l, $lvl, $tag, $($args)*)
-       }
-   };
+    ($($args:tt)*) => ($crate::log!($($args)*));
 );
+
 /// Log critical level record
 ///
 /// See `log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! crit(
     ($l:expr, #$tag:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Critical, $tag, $($args)+)
+        $crate::log!($l, $crate::Level::Critical, $tag, $($args)+)
     };
     ($l:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Critical, "", $($args)+)
+        $crate::log!($l, $crate::Level::Critical, "", $($args)+)
     };
 );
 
 /// Log critical level record (alias)
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
+/// Now it is possible to simply use the prefixed path `slog::crit!`.
 ///
 /// See `slog_log` for documentation.
 #[macro_export(local_inner_macros)]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::crit!(...) instead"
+)]
 macro_rules! slog_crit(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Critical, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Critical, "", $($args)+)
-    };
+    ($($args:tt)*) => ($crate::crit!($($args)*));
 );
 
 /// Log error level record
@@ -917,144 +815,131 @@ macro_rules! error(
 
 /// Log error level record
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::crit!(...) instead"
+)]
 macro_rules! slog_error(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Error, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Error, "", $($args)+)
-    };
+    ($($args:tt)*) => ($crate::error!($($args)*));
 );
 
 /// Log warning level record
 ///
 /// See `log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! warn(
     ($l:expr, #$tag:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Warning, $tag, $($args)+)
+        $crate::log!($l, $crate::Level::Warning, $tag, $($args)+)
     };
     ($l:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Warning, "", $($args)+)
+        $crate::log!($l, $crate::Level::Warning, "", $($args)+)
     };
 );
 
 /// Log warning level record (alias)
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::warn!(...) instead"
+)]
 macro_rules! slog_warn(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Warning, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Warning, "", $($args)+)
-    };
+    ($($args:tt)*) => ($crate::warn!($($args)*));
 );
 
 /// Log info level record
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! info(
     ($l:expr, #$tag:expr, $($args:tt)*) => {
-        log!($l, $crate::Level::Info, $tag, $($args)*)
+        $crate::log!($l, $crate::Level::Info, $tag, $($args)*)
     };
     ($l:expr, $($args:tt)*) => {
-        log!($l, $crate::Level::Info, "", $($args)*)
+        $crate::log!($l, $crate::Level::Info, "", $($args)*)
     };
 );
 
 /// Log info level record (alias)
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::info!(...) instead"
+)]
 macro_rules! slog_info(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Info, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Info, "", $($args)+)
-    };
+    ($($args:tt)*) => ($crate::info!($($args)*));
 );
 
 /// Log debug level record
 ///
 /// See `log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! debug(
     ($l:expr, #$tag:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Debug, $tag, $($args)+)
+        $crate::log!($l, $crate::Level::Debug, $tag, $($args)+)
     };
     ($l:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Debug, "", $($args)+)
+        $crate::log!($l, $crate::Level::Debug, "", $($args)+)
     };
 );
 
 /// Log debug level record (alias)
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::warn!(...) instead"
+)]
 macro_rules! slog_debug(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Debug, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Debug, "", $($args)+)
-    };
+    ($($args:tt)*) => ($crate::debug!($($args)*));
 );
 
 /// Log trace level record
 ///
 /// See `log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! trace(
     ($l:expr, #$tag:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Trace, $tag, $($args)+)
+        $crate::log!($l, $crate::Level::Trace, $tag, $($args)+)
     };
     ($l:expr, $($args:tt)+) => {
-        log!($l, $crate::Level::Trace, "", $($args)+)
+        $crate::log!($l, $crate::Level::Trace, "", $($args)+)
     };
 );
 
 /// Log trace level record (alias)
 ///
-/// Prefer shorter version, unless it clashes with
-/// existing `log` crate macro.
+/// Before Rust 2018, this alternate name was necessary in case of conflicts with the `log` crate.
 ///
 /// See `slog_log` for documentation.
-#[macro_export(local_inner_macros)]
+#[macro_export]
+#[deprecated(
+    since = "2.8.0",
+    note = "Use fully qualified macro slog::trace!(...) instead"
+)]
 macro_rules! slog_trace(
-    ($l:expr, #$tag:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Trace, $tag, $($args)+)
-    };
-    ($l:expr, $($args:tt)+) => {
-        slog_log!($l, $crate::Level::Trace, "", $($args)+)
-    };
-    ($($args:tt)+) => {
-        slog_log!($crate::Level::Trace, $($args)+)
-    };
+    ($($args:tt)*) => ($crate::trace!($($args)*));
 );
 
 /// Helper macro for using the built-in macros inside of
 /// exposed macros with `local_inner_macros` attribute.
 #[doc(hidden)]
-#[macro_export]
-macro_rules! __slog_builtin {
+#[macro_export] // TODO: Always use explicit paths
+macro_rules! __builtin {
     (@format_args $($t:tt)*) => ( format_args!($($t)*) );
     (@stringify $($t:tt)*) => ( stringify!($($t)*) );
     (@file) => ( file!() );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,7 @@ mod no_imports {
     /// ensure o! macro expands without error inside a module
     #[test]
     fn test_slog_o_macro_expansion() {
-        let _ = Logger::root(Discard, slog_o!("a" => "aa"));
+        let _ = Logger::root(Discard, crate::o!("a" => "aa"));
     }
 }
 
@@ -163,7 +163,7 @@ mod std_only {
         let logger =
             Logger::root(CheckError, o!("error" => #TestError::new("foo")));
         info!(logger, "foo");
-        slog_info!(logger, "foo");
+        crate::info!(logger, "foo");
     }
 
     #[test]
@@ -172,7 +172,7 @@ mod std_only {
         let error = &error;
         let logger = Logger::root(CheckError, o!());
         info!(logger, "foo"; "error" => #error);
-        slog_info!(logger, "foo"; "error" => #error);
+        crate::info!(logger, "foo"; "error" => #error);
     }
 
     #[test]
@@ -182,7 +182,7 @@ mod std_only {
             o!("error" => #TestError::new("foo"), "not-error" => "not-error"),
         );
         info!(logger, "not-error: not-error; foo");
-        slog_info!(logger, "not-error: not-error; foo");
+        crate::info!(logger, "not-error: not-error; foo");
     }
 
     #[test]
@@ -191,7 +191,7 @@ mod std_only {
         let error = &error;
         let logger = Logger::root(CheckError, o!());
         info!(logger, "not-error: not-error; foo"; "error" => #error, "not-error" => "not-error");
-        slog_info!(logger, "not-error: not-error; foo"; "error" => #error, "not-error" => "not-error");
+        crate::info!(logger, "not-error: not-error; foo"; "error" => #error, "not-error" => "not-error");
     }
 
     #[test]
@@ -201,7 +201,7 @@ mod std_only {
             o!("not-error" => "not-error", "error" => #TestError::new("foo")),
         );
         info!(logger, "foonot-error: not-error; ");
-        slog_info!(logger, "foonot-error: not-error; ");
+        crate::info!(logger, "foonot-error: not-error; ");
     }
 
     #[test]
@@ -210,7 +210,7 @@ mod std_only {
         let error = &error;
         let logger = Logger::root(CheckError, o!());
         info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => #error);
-        slog_info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => #error);
+        crate::info!(logger, "foonot-error: not-error; "; "not-error" => "not-error", "error" => #error);
     }
 
     #[test]
@@ -220,7 +220,7 @@ mod std_only {
             o!("error" => #TestError("foo", Some(TestError::new("bar")))),
         );
         info!(logger, "foo: bar");
-        slog_info!(logger, "foo: bar");
+        crate::info!(logger, "foo: bar");
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod std_only {
         let error = &error;
         let logger = Logger::root(CheckError, o!());
         info!(logger, "foo: bar"; "error" => #error);
-        slog_info!(logger, "foo: bar"; "error" => #error);
+        crate::info!(logger, "foo: bar"; "error" => #error);
     }
 
     #[test]
@@ -239,7 +239,7 @@ mod std_only {
             o!("error" => #TestError("foo", Some(TestError("bar", Some(TestError::new("baz")))))),
         );
         info!(logger, "foo: bar: baz");
-        slog_info!(logger, "foo: bar: baz");
+        crate::info!(logger, "foo: bar: baz");
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod std_only {
         let error = &error;
         let logger = Logger::root(CheckError, o!());
         info!(logger, "foo: bar: baz"; "error" => #error);
-        slog_info!(logger, "foo: bar: baz"; "error" => #error);
+        crate::info!(logger, "foo: bar: baz"; "error" => #error);
     }
 
     #[test]
@@ -289,16 +289,16 @@ fn expressions() {
     let r = X { foo };
 
     warn!(log, "logging message");
-    slog_warn!(log, "logging message");
+    crate::warn!(log, "logging message");
 
     info!(log, #"with tag", "logging message");
-    slog_info!(log, #"with tag", "logging message");
+    crate::info!(log, #"with tag", "logging message");
 
     warn!(log, "logging message"; "a" => "b");
-    slog_warn!(log, "logging message"; "a" => "b");
+    crate::warn!(log, "logging message"; "a" => "b");
 
     warn!(log, "logging message bar={}", r.foo.bar());
-    slog_warn!(log, "logging message bar={}", r.foo.bar());
+    crate::warn!(log, "logging message bar={}", r.foo.bar());
 
     warn!(
         log,
@@ -306,7 +306,7 @@ fn expressions() {
         r.foo.bar(),
         r.foo.bar()
     );
-    slog_warn!(
+    crate::warn!(
         log,
         "logging message bar={} foo={}",
         r.foo.bar(),
@@ -320,7 +320,7 @@ fn expressions() {
         r.foo.bar(),
         r.foo.bar(),
     );
-    slog_warn!(
+    crate::warn!(
         log,
         "logging message bar={} foo={}",
         r.foo.bar(),
@@ -328,24 +328,24 @@ fn expressions() {
     );
 
     warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1);
-    slog_warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1);
+    crate::warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1);
 
     // trailing comma check
     warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1,);
-    slog_warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1,);
+    crate::warn!(log, "logging message bar={}", r.foo.bar(); "x" => 1,);
 
     warn!(log,
           "logging message bar={}", r.foo.bar(); "x" => 1, "y" => r.foo.bar());
-    slog_warn!(log,
+    crate::warn!(log,
                "logging message bar={}", r.foo.bar();
                "x" => 1, "y" => r.foo.bar());
 
     warn!(log, "logging message bar={}", r.foo.bar(); "x" => r.foo.bar());
-    slog_warn!(log, "logging message bar={}", r.foo.bar(); "x" => r.foo.bar());
+    crate::warn!(log, "logging message bar={}", r.foo.bar(); "x" => r.foo.bar());
 
     warn!(log, "logging message bar={}", r.foo.bar();
           "x" => r.foo.bar(), "y" => r.foo.bar());
-    slog_warn!(log,
+    crate::warn!(log,
                "logging message bar={}", r.foo.bar();
                "x" => r.foo.bar(), "y" => r.foo.bar());
 
@@ -353,7 +353,7 @@ fn expressions() {
     warn!(log,
           "logging message bar={}", r.foo.bar();
           "x" => r.foo.bar(), "y" => r.foo.bar(),);
-    slog_warn!(log,
+    crate::warn!(log,
                "logging message bar={}", r.foo.bar();
                "x" => r.foo.bar(), "y" => r.foo.bar(),);
 
@@ -376,8 +376,9 @@ fn expressions() {
         let _log = log.new(o!(x.clone()));
         let _log = log.new(o!("foo" => "bar", x.clone()));
         let _log = log.new(o!("foo" => "bar", x.clone(), x.clone()));
-        let _log = log
-            .new(slog_o!("foo" => "bar", x.clone(), x.clone(), "aaa" => "bbb"));
+        let _log = log.new(
+            crate::o!("foo" => "bar", x.clone(), x.clone(), "aaa" => "bbb"),
+        );
 
         info!(log, "message"; "foo" => "bar", &x, &x, "aaa" => "bbb");
     }


### PR DESCRIPTION
These are made redundant by the new macro path system in Rust 2018. For example, we can now use `slog::log!()` instead of needing `slog_log!`.

This warning can be disabled with the feature flag: `suppress-macro2018-warnings`

**TODO**
* [x] Add an entry to CHANGELOG.md
* [x] Consider how this affects other changes/improvements to the macros
    * ~~Do we want to use procedural macros?~~ - This is orthogonal to this issue. 