### PR TITLE
feat: Add `flush` method on `Drain` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add `ErrorRef` wrapper to enable logging error references (PR #327)
   * The `#` error formatter in macros was updated to automatically select `ErrorValue` or `ErrorRef` (PR #328)
+* Add `flush` method to `Drain` trait (PR #322). 
+  Only the `Async` drain supports this feature and checks if
+  the channel is emptied.
 
 ### 2.8.0-beta.1 - 2023-09-09
 


### PR DESCRIPTION
Closes: https://github.com/slog-rs/async/issues/35
This needs to be thoroughly reviewed, not sure if its good enough =)

- The return type `io:Result<()>` could not be turned into `result::Result<Self::Ok, Self::Err>` since that would need some more redirection or, or I use `result::Result<Self::Ok, Self::Err>` and return `Ok(Self::Ok::new())` if possible in the default `flush()` implementation.

Make sure to:

* [x] Add an entry to CHANGELOG.md (if necessary)
