### PR TITLE
Improve docs for `slog::Value` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* doc: Fix typo in slog::Value docs (issue #335)
+  * Thank you to @larswirzenius for noticing this!
 * doc: Fix "lazy continuation" in `slog::Logger` doc
   * This mistake was caught by a new lint [`#[warn(clippy::doc_lazy_continuation)]`](https://rust-lang.github.io/rust-clippy/rust-1.81.0/index.html#/doc_lazy_continuation)
 * Fix some internal warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2953,7 +2953,7 @@ where
 // {{{ Value
 /// Value that can be serialized
 ///
-/// Types that implement this type implement custom serialization in the
+/// Types that implement this trait implement custom serialization in the
 /// structured part of the log macros. Without an implementation of `Value` for
 /// your type you must emit using either the `?` "debug", `#?` "pretty-debug",
 /// `%` "display", `#%` "alternate display" or [`SerdeValue`](trait.SerdeValue.html)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2953,7 +2953,7 @@ where
 // {{{ Value
 /// Value that can be serialized
 ///
-/// Types that implement this trait implement custom serialization in the
+/// Types that implement this trait have custom serialization in the
 /// structured part of the log macros. Without an implementation of `Value` for
 /// your type you must emit using either the `?` "debug", `#?` "pretty-debug",
 /// `%` "display", `#%` "alternate display" or [`SerdeValue`](trait.SerdeValue.html)


### PR DESCRIPTION
- Typo: The phrase "implement this *type*" should be "implement this *trait*" -- Thanks to @larswirzenius for noticing this
   - Fixes issue #335 
- Style: Avoid using the word "implement" twice in a row