### PR TITLE
RFC: Enable nested-values feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* **BIG**: Enables the `nested-values` feature by default.
 * Deprecate old prefixed macros like `slog_log`.
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ lto = true
 debug-assertions = false
 
 [features]
-default = ["std"]
+default = ["std", "nested-values"]
 # Support nesting values in log messages using serde
 #
 # Using this is recommended to improve the detail of log messages.


### PR DESCRIPTION
This changes the `nested-values` feature to be on by default as part of the slog 2.8 release.

I will to add similar PRs to enable this by default in `slog_term`, `slog_async`, `slog_json`, and others. I will bump the minor version of each crate when making the feature the default.

## Advantages
The `nested-values` feature is very useful, but enabling it requires you to turn on the flag in every supported crate.

```toml
slog = { version = "2", features = ["nested-values"] }
slog-term = { version = "2.9", features = ["nested-values"] }
slog-async = { version = "2.8", features = ["nested-values"] }
slog-json = { version = "2.6", features = ["nested-values"] }
```

If you forget to enable one of these features, you will get a vague error message. One of the fixes in PR #345 is to improve the error message when `nested-values` is unsupported; however enabling this feature by default across all our crates will help avoid the error altogether.

If this PR is accepted, all you would need to do is depend on a new enough version of the crate in question:

```toml
slog = "2.8"
slog-term =  "2.10"
slog-async = "2.9"
slog-json = "2.7"
```

*NOTE*: These are the upcoming versions of the crates and have not been released. If this PR is accepted, they will all have `nested-values` enabled by default.

## Disadvantages
This requires bumping the MSRV to [Rust 1.56], because that is the MSRV of `erased-serde`. Many important rust libraries (`serde_derive`, `syn`, `indexmap`, `log`, `clap`) already require this version.

On my M1 Mac, this makes a clean build take ~1 sec longer, and slower computers might be worse. Incremental builds should not be affected since dependencies are cached. Also note that as of 5a51d79eI slog doesn't depend on `serde_derive`, so there is no direct/indirect dependency on `syn`.

Not all loggers currently support `nested-values`, so users might get an error if they try to use the now default feature.

[Rust 1.56]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/

## Alternatives
Rely on the current system, which requires flipping multiple feature flags across crates. 

Figure out a way to give compile-time warnings if some crates have `nested-values` enabled but others don't.

# Request for Comments
Place a :thumbsup: if you think this is a good idea, and 👎 if you think it is a bad one.

Based on the feedback here, I will decide whether to include this.

Related issues:
- #236 
- #233 
- #232
