### PR TITLE
Define a 'prelude' module for common imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Optionally implement Drain for [`parking_lot::Mutex`].
   This is noticeably faster than `std::sync::Mutex` in the uncontented case, is smaller, and avoids poisoning.
   * This feature has a separate name per version to allow supporting multiple versions of `parking_lot` at once. The current version (v0.12) has feature name `parking_lot_0_12`
+* Define a `prelude` module for common imports, allowing import of logging macros (`info!`, `!debug`, ...) and `slog::Logger` in one go.
 
 [`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html
 

--- a/examples/named.rs
+++ b/examples/named.rs
@@ -1,10 +1,13 @@
 //#![feature(trace_macros)]
-use slog::{info, o, Fuse, Logger};
+use slog::prelude::*;
 
 mod common;
 
 fn main() {
-    let log = Logger::root(Fuse(common::PrintlnDrain), o!("version" => "2"));
+    let log = Logger::root(
+        slog::Fuse(common::PrintlnDrain),
+        slog::o!("version" => "2"),
+    );
 
     //trace_macros!(true);
     info!(log, "foo is {foo}", foo = 2; "a" => "b");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,8 @@ use core::error::Error as StdError;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
+pub mod prelude;
+
 // }}}
 
 // {{{ Macros

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,23 @@
+//! A set of common imports needed by most programs that use `slog`.
+//!
+//! It is intended to be used like follows:
+//! ```
+//! use slog::prelude::*;
+//! fn my_func(logger: &Logger, x: i32) {
+//!     info!(logger, "slog rules!"; "x" => x);
+//!     if x < 0 {
+//!         warn!(logger, "negative numbers are scary"; "x" => x);
+//!     }
+//! }
+//! ```
+//!
+//! This includes the logging macros ([`log!`](crate::log), [`trace!`](crate::trace), ...) and [`slog::Logger`](crate::Logger).
+//! It also includes [`slog::Serde`] and [`slog::FnValue`], as those are frequently useful as well.
+//!
+//! Adding new items here is a breaking change,
+//! because it can cause conflicts with other bulk-imported modules.
+
+#[cfg(feature = "nested-values")]
+pub use crate::Serde;
+pub use crate::{crit, debug, error, info, log, trace, warn};
+pub use crate::{FnValue, Logger};

--- a/tests/prelude_conflicts.rs
+++ b/tests/prelude_conflicts.rs
@@ -1,0 +1,27 @@
+#![allow(unused_variables)]
+use self::conflicting::{FnValue, Serde};
+// this import is supposed to be unused
+#[rustversion::attr(since(1.81), expect(unused_imports))]
+#[rustversion::attr(before(1.81), allow(unused_imports))]
+use slog::prelude::*;
+
+#[allow(dead_code)]
+mod conflicting {
+    pub struct Serde(pub i32);
+    pub struct FnValue(pub i32);
+}
+
+#[test]
+fn conflicts_serde() {
+    let x = Serde(3);
+    let x: conflicting::Serde = x;
+    let _ = x;
+}
+
+#[test]
+fn conflicts_fn_value() {
+    // explicit type needed due to dependency_on_unit_never_type_fallback
+    let x = slog::FnValue::<(), _>(|x| panic!());
+    let x = FnValue(3);
+    let x: conflicting::FnValue = x;
+}


### PR DESCRIPTION
This will make imports more convenient.

*TODO*: Decide if the following items should be included:
- `slog::FnValue`
- `slog::Serde`
- `slog::PushFnValue`

~~**EDIT**: I conservatively decided against including these items.~~

**EDIT 2**: I decided to include the first two