### PR TITLE
Optionally implement Drain for parking_lot::Mutex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,10 @@ jobs:
           - "std nothreads"
           - "std nested-values dynamic-keys"
           - "std nested-values dynamic-keys nothreads"
+        include:
+          # Our MSRV doesn't support parking_lot, so explicitly test it here
+          - rust: stable
+            features: "std parking_lot"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* **BIG**: Enables the `nested-values` feature by default.
 * Deprecate old prefixed macros like `slog_log`.
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **BIG**: Enables the `nested-values` feature by default.
 * Deprecate old prefixed macros like `slog_log`.
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
+* Optionally implement Drain for [`parking_lot::Mutex`].
+  This is noticeably faster than `std::sync::Mutex` in the uncontented case, is smaller, and avoids poisoning.
+
+[`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html
 
 ### 2.8.0-rc.1 - 2025-08-06
 * Minimum Supported Rust Version is now [1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ lto = true
 debug-assertions = false
 
 [features]
-default = ["std"]
+default = ["std", "nested-values"]
 # Support nesting values in log messages using serde
 #
 # Using this is recommended to improve the detail of log messages.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,13 @@ nothreads = []
 # Implement serde::Value for anyhow::Error
 # anyhow = ["dep:anyhow"]
 
+# Implement slog::Drain for parking_lot::Mutex
+#
+# Because parking_lot has not reached 1.0 yet,
+# slog may update the version of parking_lot at any time,
+# even in a patch release (2.8.x)
+# parking_lot = ["dep:parking_lot"]
+
 max_level_off   = []
 max_level_error = []
 max_level_warn  = []
@@ -96,6 +103,7 @@ release_max_level_trace = []
 # TODO: The std feature should imply serde?/std, but weak feature dependencies need Rust 1.60
 serde = { version = "1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }
+parking_lot = { version = "0.12", optional = true }
 
 [dependencies.erased-serde]
 # The 0.3 series of erased-serde has MSRV 1.56, but the 0.4 series requires Rust 1.61

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1921,6 +1921,24 @@ impl<D: Drain> Drain for std::sync::Mutex<D> {
         self.lock().ok().map_or(true, |lock| lock.is_enabled(level))
     }
 }
+
+#[cfg(feature = "parking_lot")]
+impl<D: Drain> Drain for parking_lot::Mutex<D> {
+    type Ok = D::Ok;
+    type Err = D::Err;
+    fn log(
+        &self,
+        record: &Record<'_>,
+        logger_values: &OwnedKVList,
+    ) -> result::Result<Self::Ok, Self::Err> {
+        let d = self.lock();
+        d.log(record, logger_values)
+    }
+    #[inline]
+    fn is_enabled(&self, level: Level) -> bool {
+        self.lock().is_enabled(level)
+    }
+}
 // }}}
 
 // {{{ Level & FilterLevel


### PR DESCRIPTION
This is noticeably faster than std::sync::Mutex when contention is low, smaller, and avoids dealing with poisoning.

Until `parking_lot` reaches a 1.0 release, we can update the version at any time.
