### PR TITLE
ci: Avoid running spellcheck twice on same-repo PRs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   typos:
+    # Only run on PRs if the source branch is on someone else's repo
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+
     name: Check spelling with typos
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is inconsistent with the behavior of all other workflows.
