### PR TITLE
Upgrade nested-values to v0.4 and MSRV to 1.61

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           # you need to remove this from the main list and manually add the desired
           # feature/version combinations to 'include'
           # This hack is not currently needed because serde-erased v0.3 supports our MSRV.
-          - 1.56
+          - 1.61
 
           # Per the MSRV policy (discussed in Wiki/docs), this places an upper bound on the MSRV
           #
@@ -44,8 +44,8 @@ jobs:
           #
           # Intermediate Releases (between MSRV and latest stable)
           # Be careful not to add these needlessly; they hold up CI
-          #
-          - 1.61
+          # <nothing currently>
+
           # The most recent version of stable rust (automatically updated)
           - stable
           - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 * **BIG**: Enables the `nested-values` feature by default.
 * Bump MSRV to 1.61.
+* Update `erased-serde` from v0.3 to v0.4
 * Deprecate old prefixed macros like `slog_log`.
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
 * Optionally implement Drain for [`parking_lot::Mutex`].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 * **BIG**: Enables the `nested-values` feature by default.
+* Bump MSRV to 1.61.
 * Deprecate old prefixed macros like `slog_log`.
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
 * Optionally implement Drain for [`parking_lot::Mutex`].

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 # - .github/workflows/test.yml (Github Actions)
 # - README.md
 # - clippy.toml (Clippy config)
-rust-version = "1.56"
+rust-version = "1.61"
 
 [profile.release]
 opt-level = 3
@@ -59,7 +59,7 @@ nested-values = ["erased-serde", "serde"]
 # without breaking other libraries.
 dynamic-keys = []
 # Require the standard library.
-std = []
+std = ["serde?/std", "anyhow?/std"]
 # DANGER: Remove the Send + Sync bound from the default logger and drain.
 #
 # This feature is highly discouraged, because it could break other libraries relying on slog.
@@ -100,7 +100,6 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 [dependencies]
-# TODO: The std feature should imply serde?/std, but weak feature dependencies need Rust 1.60
 serde = { version = "1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,8 @@ anyhow = { version = "1", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 
 [dependencies.erased-serde]
-# The 0.3 series of erased-serde has MSRV 1.56, but the 0.4 series requires Rust 1.61
-# Since we want to support old rust, we stick with the old 0.3 series
-version = "0.3"
+# The 0.4 series of erased-serde has MSRV Rust 1.61, just like we do
+version = "0.4"
 optional = true
 default-features = false
 features = ["alloc"]  # erased-serde always requires alloc, and so does slog

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
       <img src="https://docs.rs/slog/badge.svg" alt="docs-rs: release versions documentation">
   </a>
   <!-- Badge showing our Minimum Supported Rust Version, along with a link to the release announcement on the official blog -->
-  <a href="https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/">
-      <img src="https://img.shields.io/badge/rust-1.56%2B-orange.svg">
+  <a href="https://blog.rust-lang.org/2022/05/19/Rust-1.61.0/">
+      <img src="https://img.shields.io/badge/rust-1.61%2B-blue.svg">
   </a>
   <br>
     <strong><a href="https://github.com/slog-rs/slog/wiki/Getting-started">Getting started</a></strong>

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -5,7 +5,7 @@ pub struct PrintlnSerializer;
 
 impl Serializer for PrintlnSerializer {
     fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments<'_>) -> Result {
-        print!(", {}={}", key, val);
+        print!(", {key}={val}");
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,11 @@
     clippy::std_instead_of_core,
     clippy::std_instead_of_alloc,
 )]
+#![allow(
+    // Thiw lint was triggered by bumping the MSRV to 1.61
+    // TODO: Apply suggestions rather than suppressing
+    clippy::uninlined_format_args,
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -148,8 +148,6 @@ mod std_only {
         info!(logger, "foo"; "error" => #&error);
     }
 
-    // requires `impl Error for Arc<T>` - since 1.52
-    #[rustversion::since(1.52)]
     #[test]
     fn error_arc_ref() {
         let error = TestError::new("foo");


### PR DESCRIPTION
Upgrading `nested-values` from v0.3 to v0.4 requires Rust 1.61.

Most of the Rust ecosystem now requires at least 1.61, including `slog_term`, `log`, and `serde-derive`. The MSRV upgrade is permissible because of the 2.7 to 2.8 version bump.