### PR TITLE
Rename 'parking_lot' feature to 'parking_lot_0_12'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         include:
           # Our MSRV doesn't support parking_lot, so explicitly test it here
           - rust: stable
-            features: "std parking_lot"
+            features: "std parking_lot_0_12"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Rust 2018 macro paths make these unnecessary, use `slog::log!` instead.
 * Optionally implement Drain for [`parking_lot::Mutex`].
   This is noticeably faster than `std::sync::Mutex` in the uncontented case, is smaller, and avoids poisoning.
+  * This feature has a separate name per version to allow supporting multiple versions of `parking_lot` at once. The current version (v0.12) has feature name `parking_lot_0_12`
 
 [`parking_lot::Mutex`]: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,23 @@ nothreads = []
 # Implement serde::Value for anyhow::Error
 anyhow = ["dep:anyhow"]
 
-# Implement slog::Drain for parking_lot::Mutex
+# Implement slog::Drain for parking_lot::Mutex.
 #
-# Because parking_lot has not reached 1.0 yet,
-# slog may update the version of parking_lot at any time,
-# even in a patch release (2.8.x)
-parking_lot = ["dep:parking_lot"]
+# Each version of parking_lot has a separate feature name,
+# so that multiple versions of parking_lot can be supported at once without causing conflicts.
+# This works because Cargo supports depending on multiple versions of the same crate,
+# and Rust considers parking_lot_0_12::Mutex and parking_lot1::Mutex as completely different types.
+#
+# Compatibility Guarantees:
+# New versions of parking_lot can be added in a patch version of slog (2.8.1 -> 2.8.2)
+#
+# Support for an old version of parking_lot will be reatined as long as reasonably possible,
+# and only removed if it causes significant issues or is known to be severely buggy.
+# In the exceptional event that support for an old version is removed,
+# it will only happen in a slog minor version upgrade (2.8 -> 2.9), never in a patch version upgrade.
+#
+# A hypothetical parking_lot v1.0 release would be named `parking_lot1` rather than `parking_lot_1`.
+parking_lot_0_12 = ["dep:parking_lot_0_12"]
 
 # Control the log level at compile-time
 
@@ -96,7 +107,7 @@ release_max_level_trace = []
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }
-parking_lot = { version = "0.12", optional = true }
+parking_lot_0_12 = { package = "parking_lot", version = "0.12", optional = true }
 
 [dependencies.erased-serde]
 # The 0.4 series of erased-serde has MSRV Rust 1.61, just like we do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1927,8 +1927,8 @@ impl<D: Drain> Drain for std::sync::Mutex<D> {
     }
 }
 
-#[cfg(feature = "parking_lot")]
-impl<D: Drain> Drain for parking_lot::Mutex<D> {
+#[cfg(feature = "parking_lot_0_12")]
+impl<D: Drain> Drain for parking_lot_0_12::Mutex<D> {
     type Ok = D::Ok;
     type Err = D::Err;
     fn log(


### PR DESCRIPTION
The old policy allowing breaking upgrades on a minor version was unacceptable.
An upgrade from `parking_lot` v0.12 to v0.13 would cause very significant breakage and should not be part of a patch release of slog.

Namespacing these features by version allows us to support multiple versions at once and avoid breaking code when `parking_lot` upgrades.

This change is not breaking, since `parking_lot` support was added in 4bd87beb6c5 which is not part of any released version.

Here are the new compatibility guarantees from Cargo.toml:
```
# New versions of parking_lot can be added in a patch version of slog (2.8.1 -> 2.8.2)
#
# Support for an old version of parking_lot will be reatined as long as reasonably possible,
# and only removed if it causes significant issues or is known to be severely buggy.
# In the exceptional event that support for an old version is removed,
# it will only happen in a slog minor version upgrade (2.8 -> 2.9), never in a patch version upgrade.
#
# A hypothetical parking_lot v1.0 release would be named `parking_lot1` rather than `parking_lot_1`.
```

