### PR TITLE
Attempt to support #[track_caller]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ serde_derive = "1"
 name = "singlethread"
 required-features = ["nothreads"]
 
+[[test]]
+name = "track_caller"
+path = "tests/track_caller/mod.rs"
+
 [package.metadata.docs.rs]
 features = ["std", "nested-values", "dynamic-keys"]
 

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,14 @@ pub fn main() {
         // Renaming imports using the clippy-disallowed-types lint doesn't work
         println!("cargo:rustc-cfg=has_std_error")
     }
+    if rustversion::cfg!(since(1.79)) {
+        // use core::panic::Location::caller() rather than file!(), line!(), column!() macros.
+        // This requires inline const { ... } expressions and Location::caller() to be a const-fn
+        // Both are added in Rust 1.79
+        println!("cargo:rustc-cfg=use_const_location");
+    }
     if rustversion::cfg!(since(1.80)) {
+        println!("cargo:rustc-check-cfg=cfg(use_const_location)");
         println!("cargo:rustc-check-cfg=cfg(has_std_error)")
     }
 }

--- a/tests/track_caller/mod.rs
+++ b/tests/track_caller/mod.rs
@@ -1,0 +1,38 @@
+//! Tests that slog respects `#[track_caller]`
+//!
+//! WARNING: Formatting changes to this file will disrupt the line and column numbers,
+//! triggering test failures.
+//! You have been warned.
+
+use std::panic::Location;
+
+// NOTE: Using a path attribute here breaks Location.file()
+mod separate_file;
+
+#[test]
+#[rustversion::attr(before(1.79), ignore = "no const Location::caller")]
+fn track_caller() {
+    let record = separate_file::record_track();
+    assert_eq!(record.file(), Location::caller().file());
+    assert_eq!(record.line(), 12);
+    assert_eq!(record.column(), 5);
+}
+
+#[test]
+fn no_track_caller() {
+    let record = separate_file::record_no_track();
+    assert_eq!(record.file(), "tests/track_caller/separate_file.rs");
+    assert_eq!(record.line(), 7);
+    assert_eq!(record.column(), 18);
+}
+
+#[test]
+fn track_caller_loc() {
+    let loc = const { indirect() };
+    assert_eq!(loc.line(), 31)
+}
+
+#[track_caller]
+const fn indirect() -> &'static core::panic::Location<'static> {
+    Location::caller()
+}

--- a/tests/track_caller/separate_file.rs
+++ b/tests/track_caller/separate_file.rs
@@ -1,0 +1,14 @@
+//! WARNING: Formatting changes to this file will disrupt the line and column numbers,
+//! triggering test failures.
+//! You have been warned.
+
+pub fn record_no_track() -> slog::Record<'static> {
+    let args = Box::leak(Box::new(format_args!("problem!")));
+    slog::record!(slog::Level::Warning, "", args, slog::b!())
+}
+
+#[track_caller]
+pub fn record_track() -> slog::Record<'static> {
+    let args = Box::leak(Box::new(format_args!("problem!")));
+    slog::record!(slog::Level::Warning, "", args, slog::b!())
+}


### PR DESCRIPTION
Attempt to fix issue #42

Due to the need to create `&'static RecordStatic` at compile time, this is much more difficult than adding support in the log crate.

I tried various combination of inline const and const declaration.
In each case, the `track_caller::track_caller` test failed to respect the `#[track_caller]` attribute.

It turns out that there is a bizarre interaction that means `Location::caller` does not respect `#[track_caller]` in a const-eval context.

See here for a demo:
https://gist.github.com/Techcable/a80e3a4c4d928a2038dc45bd6d91f9e4

A workaround would be adding a `&'static Location` to the `slog::Record` struct, but this would add another pointer to the record and possibly break backwards compatibility.
