### PR TITLE
regression fix: restore compatibility with `erased-serde` version 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- **[Fix]** Restore compatibility with `erased-serde` version `0.3`.
+  - Compatibility with `erased-serde` version `0.4` may be provided again in a
+    future version.
+
 ## [2.8.0] - 2025-10-05
 This is the biggest slog release since 2.0. It fully preserves compatibility with prior releases.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ default = ["std", "nested-values"]
 # Without it, only flat values like numbers and strings can be logged.
 # This requires the underlying logger to support this feature,
 # usually requiring a nested-values feature flag on the logging backend.
-#
-# NOTE: Using nested-values requires Rust 1.56
 nested-values = ["dep:erased-serde", "dep:serde_core"]
 # DANGER: Use a String for slog::Key insated of &'static str
 #
@@ -111,8 +109,10 @@ anyhow = { version = "1", optional = true, default-features = false }
 parking_lot_0_12 = { package = "parking_lot", version = "0.12", optional = true }
 
 [dependencies.erased-serde]
-# The 0.4 series of erased-serde has MSRV Rust 1.61, just like we do
-version = "0.4"
+# For Slog 2.x, we keep compat with `erased-serde 0.3` as it's a public
+# dependency, even if newer major versions are available.
+# erased-serde 0.3 has MSRV 1.56, which is stronger than our MSRV (1.61)
+version = "0.3"
 optional = true
 default-features = false
 features = ["alloc"]  # erased-serde always requires alloc, and so does slog

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2978,7 +2978,7 @@ impl fmt::Display for ErrorAsFmt<'_> {
 // }}}
 
 // {{{ serde
-/// A value that can be serialized via serde
+/// A value that can be serialized via `serde`, using [`erased_serde` 0.3](https://docs.rs/erased-serde/0.3).
 ///
 /// This is useful for implementing nested values, like sequences or structures.
 #[cfg(feature = "nested-values")]
@@ -3025,7 +3025,7 @@ pub trait SerdeValue: erased_serde::Serialize + Value {
         }
     }
 
-    /// Convert to `erased_serialize::Serialize` of the underlying value,
+    /// Convert to [`erased_serde::Serialize`] of the underlying value,
     /// so `slog::Serializer`s can use it to serialize via `serde`.
     fn as_serde(&self) -> &dyn erased_serde::Serialize;
 


### PR DESCRIPTION
The recent release `2.8.0` introduced a breaking change by changing the super-traits and method signatures of the `SerdeValue` trait (enabled via the `nested-value` feature). The change was the update of the public dependency `erased-serde` across semver-breaking versions. The previous version is `0.3`, the new version is `0.4`.

This commit fixes this breakage by reverting the `erased-serde` requirement to `0.3`.

- Closes #358

Make sure to:

* [x] Add an entry to CHANGELOG.md (if necessary)
