### PR TITLE
Implement slog::Value for std::sync::LazyLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixes
 * ci: Check the tests pass with `-Zminimal-versions`
 
+### Added
+* Implement slog::Value for `std::sync::LazyLock`.
+
 ## 2.8.1 - 2025-10-05
 This fixes an accidental breaking change in the v2.8.0 release,
 where the public API was changed from `erased_serde v0.4` to `erased_serde v0.3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * ci: Check the tests pass with `-Zminimal-versions`
 
 ### Added
-* Implement slog::Value for `std::sync::LazyLock`.
+* Implement slog::Value for `std::sync::LazyLock` and `std::cell::LazyCell`.
 
 ## 2.8.1 - 2025-10-05
 This fixes an accidental breaking change in the v2.8.0 release,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,11 @@ release_max_level_trace = []
 serde_core = { version = "1", optional = true, default-features = false }
 anyhow = { version = "1", optional = true, default-features = false }
 parking_lot_0_12 = { package = "parking_lot", version = "0.12", optional = true }
+# NOTE: This is just a macro (not a runtime dependency)
+#
+# It is used to conditionally enable use of newer rust language
+# features depending on the compiler features.
+rustversion = "1.0.6"
 
 [dependencies.erased-serde]
 # For Slog 2.x, we keep compat with `erased-serde 0.3` as it's a public
@@ -122,11 +127,6 @@ features = ["alloc"]  # erased-serde always requires alloc, and so does slog
 rustversion = "1.0.6"
 
 [dev-dependencies]
-# NOTE: This is just a macro (not a runtime dependency)
-#
-# It is used to conditionally enable use of newer rust language
-# features depending on the compiler features.
-rustversion = "1.0.6"
 # first version to support serde_core
 serde = "1.0.220"
 serde_derive = "1.0.220"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3334,7 +3334,7 @@ impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
         key: Key,
         serializer: &mut dyn Serializer,
     ) -> Result {
-        (**self).serialize(record, key, serializer)
+        Self::force(self).serialize(record, key, serializer)
     }
 }
 
@@ -3346,7 +3346,7 @@ impl<T: Value, F: FnOnce() -> T> Value for core::cell::LazyCell<T, F> {
         key: Key,
         serializer: &mut dyn Serializer,
     ) -> Result {
-        (**self).serialize(record, key, serializer)
+        Self::force(self).serialize(record, key, serializer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3338,6 +3338,18 @@ impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
     }
 }
 
+#[rustversion::since(1.80)]
+impl<T: Value, F: FnOnce() -> T> Value for std::cell::LazyCell<T, F> {
+    fn serialize(
+        &self,
+        record: &Record<'_>,
+        key: Key,
+        serializer: &mut dyn Serializer,
+    ) -> Result {
+        (**self).serialize(record, key, serializer)
+    }
+}
+
 #[cfg(feature = "std")]
 impl Value for std::path::Display<'_> {
     fn serialize(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3339,7 +3339,7 @@ impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
 }
 
 #[rustversion::since(1.80)]
-impl<T: Value, F: FnOnce() -> T> Value for std::cell::LazyCell<T, F> {
+impl<T: Value, F: FnOnce() -> T> Value for core::cell::LazyCell<T, F> {
     fn serialize(
         &self,
         record: &Record<'_>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3327,6 +3327,7 @@ where
 
 #[cfg(feature = "std")]
 #[rustversion::since(1.80)]
+#[clippy::msrv = "1.80"]
 impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
     fn serialize(
         &self,
@@ -3339,6 +3340,7 @@ impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
 }
 
 #[rustversion::since(1.80)]
+#[clippy::msrv = "1.80"]
 impl<T: Value, F: FnOnce() -> T> Value for core::cell::LazyCell<T, F> {
     fn serialize(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3326,6 +3326,19 @@ where
 }
 
 #[cfg(feature = "std")]
+#[rustversion::since(1.80)]
+impl<T: Value, F: FnOnce() -> T> Value for std::sync::LazyLock<T, F> {
+    fn serialize(
+        &self,
+        record: &Record<'_>,
+        key: Key,
+        serializer: &mut dyn Serializer,
+    ) -> Result {
+        (**self).serialize(record, key, serializer)
+    }
+}
+
+#[cfg(feature = "std")]
 impl Value for std::path::Display<'_> {
     fn serialize(
         &self,


### PR DESCRIPTION
This impl allows using `LazyLock` like an `FnValue`. The notable difference is that `LazyLock` memoizes the function's result, whereas `FnValue` generates a fresh result every time. This is relevant when values are stored in a `Logger` for multiple log calls.

Closes #360
